### PR TITLE
Creates today page and uses MOCK DATA (not fixture) for backend currently

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ module.exports = function (api) {
       ],
       "@babel/preset-typescript",
     ],
-    plugins: [],
+    plugins: ["styled-components"],
     babelrcRoots: [".", "packages/*"],
   };
 };

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -4,7 +4,7 @@ import {
   CreateClubParams,
   CreateClubResponse,
   GetProfileResponse,
-  GetCourseResponse,
+  GetCourseScheduleResponse,
   TAUpdateStatusResponse,
   GetQuestionResponse,
   CreateQuestionResponse,
@@ -13,6 +13,7 @@ import {
   ListQuestionsResponse,
   UpdateQuestionResponse,
 } from "@template/common";
+import { MOCK_GET_COURSE_RESPONSE } from "../mocks/getCourse";
 
 class APIClient {
   private axios: AxiosInstance;
@@ -30,12 +31,18 @@ class APIClient {
     },
   };
   course = {
-    get: async (courseId: number): Promise<GetCourseResponse> => {
+    get: async (courseId: number): Promise<GetCourseScheduleResponse> => {
       const course = (await this.axios.get(`/api/v1/courses/${courseId}`)).data;
       course.officeHours.forEach((officeHour: any) =>
         parseOfficeHourDates(officeHour)
       );
       return course;
+    },
+    queues: async (courseId: number): Promise<GetCourseQueueResponse> => {
+      const queues = (
+        await this.axios.get(`/api/v1/courses/${courseId}/queues`)
+      ).data;
+      return parseQueueDates(queues);
     },
   };
   taStatus = {

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -4,7 +4,7 @@ import {
   CreateClubParams,
   CreateClubResponse,
   GetProfileResponse,
-  GetCourseScheduleResponse,
+  GetCourseResponse,
   TAUpdateStatusResponse,
   GetQuestionResponse,
   CreateQuestionResponse,
@@ -12,8 +12,9 @@ import {
   UpdateQuestionParams,
   ListQuestionsResponse,
   UpdateQuestionResponse,
+  GetCourseQueuesResponse,
+  QueuePartial,
 } from "@template/common";
-import { MOCK_GET_COURSE_RESPONSE } from "../mocks/getCourse";
 
 class APIClient {
   private axios: AxiosInstance;
@@ -31,18 +32,21 @@ class APIClient {
     },
   };
   course = {
-    get: async (courseId: number): Promise<GetCourseScheduleResponse> => {
-      const course = (await this.axios.get(`/api/v1/courses/${courseId}`)).data;
+    get: async (courseId: number): Promise<GetCourseResponse> => {
+      const course = (
+        await this.axios.get(`/api/v1/courses/${courseId}/schedule`)
+      ).data;
       course.officeHours.forEach((officeHour: any) =>
         parseOfficeHourDates(officeHour)
       );
       return course;
     },
-    queues: async (courseId: number): Promise<GetCourseQueueResponse> => {
+    queues: async (courseId: number): Promise<GetCourseQueuesResponse> => {
       const queues = (
         await this.axios.get(`/api/v1/courses/${courseId}/queues`)
       ).data;
-      return parseQueueDates(queues);
+      queues.forEach((q: QueuePartial) => parseQueueDates(q));
+      return queues;
     },
   };
   taStatus = {

--- a/packages/app/components/Today/OpenQueueCard.tsx
+++ b/packages/app/components/Today/OpenQueueCard.tsx
@@ -1,0 +1,40 @@
+import { Avatar, Button, Card } from "antd";
+import { QueuePartial } from "../../../common/index";
+import styled from "styled-components";
+
+type OpenQueueCard = {
+  queue: QueuePartial;
+};
+
+const PaddedCard = styled(Card)`
+  margin-bottom: 25px;
+`;
+
+const AvatarContainer = styled.div`
+  padding-left: 25px;
+  padding-right: 25px;
+  float: left;
+`;
+
+const OpenQueueCard = ({ queue }: OpenQueueCard) => {
+  const staffList = queue.staffList;
+  return (
+    <PaddedCard
+      title={staffList.map((staffMember) => staffMember.name).join(", ")}
+      extra={
+        <Button type="primary" size={"middle"}>
+          Join Queue
+        </Button>
+      }
+    >
+      <h1>{queue.room}</h1>
+      {staffList.map((staffMember) => (
+        <AvatarContainer key={staffMember.id}>
+          <Avatar size={128} src={staffMember.photoURL} shape="square" />
+        </AvatarContainer>
+      ))}
+    </PaddedCard>
+  );
+};
+
+export default OpenQueueCard;

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@types/jest": "^25.2.2",
     "@types/node": "^13.13.2",
     "@types/react": "^16.9.34",
+    "@types/react-big-calendar": "^0.24.2",
     "@types/socket.io-client": "^1.4.32",
     "babel-plugin-styled-components": "^1.10.7",
     "jest": "^26.0.1",

--- a/packages/app/pages/schedule.tsx
+++ b/packages/app/pages/schedule.tsx
@@ -4,7 +4,11 @@ import useSWR from "swr";
 import { API } from "@template/api-client";
 import { Result } from "antd";
 
-export default function Schedule() {
+type ScheduleProps = {
+  viewType: Calendar.Views; // TODO: debug this, hwy isn't it finding the types?
+};
+
+export default function Schedule({ viewType }: ScheduleProps) {
   const { data, error } = useSWR(`api/v1/courses/1`, async () =>
     API.course.get(1)
   );
@@ -27,7 +31,11 @@ export default function Schedule() {
   return (
     <div style={{ height: "400px" }}>
       <h1>{data?.name ?? ""}</h1>
-      <Calendar localizer={momentLocalizer(moment)} events={myEvents} />
+      <Calendar
+        localizer={momentLocalizer(moment)}
+        events={myEvents}
+        defaultView={viewType}
+      />
     </div>
   );
 }

--- a/packages/app/pages/schedule.tsx
+++ b/packages/app/pages/schedule.tsx
@@ -14,10 +14,8 @@ type ScheduleProps = {
 };
 
 export default function Schedule({ viewType }: ScheduleProps) {
-  const { data, error } = useSWR(
-    `api/v1/courses/1/schedule`,
-    async () => API.course.get(1),
-    { revalidateOnFocus: false }
+  const { data, error } = useSWR(`api/v1/courses/1/schedule`, async () =>
+    API.course.get(1)
   );
 
   if (error)

--- a/packages/app/pages/schedule.tsx
+++ b/packages/app/pages/schedule.tsx
@@ -1,16 +1,23 @@
-import { Calendar, momentLocalizer } from "react-big-calendar";
+import { Calendar, momentLocalizer, View } from "react-big-calendar";
 import moment from "moment";
 import useSWR from "swr";
 import { API } from "@template/api-client";
 import { Result } from "antd";
+import styled from "styled-components";
 
 type ScheduleProps = {
-  viewType: Calendar.Views; // TODO: debug this, hwy isn't it finding the types?
+  viewType: View;
 };
 
+const CalendarContainer = styled.div`
+  height: 70%;
+`;
+
 export default function Schedule({ viewType }: ScheduleProps) {
-  const { data, error } = useSWR(`api/v1/courses/1/schedule`, async () =>
-    API.course.get(1)
+  const { data, error } = useSWR(
+    `api/v1/courses/1/schedule`,
+    async () => API.course.get(1),
+    { revalidateOnFocus: false }
   );
 
   if (error)
@@ -29,12 +36,12 @@ export default function Schedule({ viewType }: ScheduleProps) {
   // TODO: frontend guru pls cleanup height <3, month view is crunked :)
   // esp on mobile
   return (
-    <div style={{ height: "70%" }}>
+    <CalendarContainer>
       <Calendar
         localizer={momentLocalizer(moment)}
         events={myEvents}
         defaultView={viewType}
       />
-    </div>
+    </CalendarContainer>
   );
 }

--- a/packages/app/pages/schedule.tsx
+++ b/packages/app/pages/schedule.tsx
@@ -5,13 +5,13 @@ import { API } from "@template/api-client";
 import { Result } from "antd";
 import styled from "styled-components";
 
+const ScheduleCalendar = styled(Calendar)`
+  height: 70vh;
+`;
+
 type ScheduleProps = {
   viewType: View;
 };
-
-const CalendarContainer = styled.div`
-  height: 70%;
-`;
 
 export default function Schedule({ viewType }: ScheduleProps) {
   const { data, error } = useSWR(
@@ -33,15 +33,12 @@ export default function Schedule({ viewType }: ScheduleProps) {
       start: e.startTime,
       end: e.endTime,
     })) ?? [];
-  // TODO: frontend guru pls cleanup height <3, month view is crunked :)
-  // esp on mobile
+
   return (
-    <CalendarContainer>
-      <Calendar
-        localizer={momentLocalizer(moment)}
-        events={myEvents}
-        defaultView={viewType}
-      />
-    </CalendarContainer>
+    <ScheduleCalendar
+      localizer={momentLocalizer(moment)}
+      events={myEvents}
+      defaultView={viewType}
+    />
   );
 }

--- a/packages/app/pages/schedule.tsx
+++ b/packages/app/pages/schedule.tsx
@@ -9,7 +9,7 @@ type ScheduleProps = {
 };
 
 export default function Schedule({ viewType }: ScheduleProps) {
-  const { data, error } = useSWR(`api/v1/courses/1`, async () =>
+  const { data, error } = useSWR(`api/v1/courses/1/schedule`, async () =>
     API.course.get(1)
   );
 
@@ -23,14 +23,13 @@ export default function Schedule({ viewType }: ScheduleProps) {
 
   const myEvents =
     data?.officeHours.map((e) => ({
-      title: e.title,
       start: e.startTime,
       end: e.endTime,
     })) ?? [];
-
+  // TODO: frontend guru pls cleanup height <3, month view is crunked :)
+  // esp on mobile
   return (
-    <div style={{ height: "400px" }}>
-      <h1>{data?.name ?? ""}</h1>
+    <div style={{ height: "70%" }}>
       <Calendar
         localizer={momentLocalizer(moment)}
         events={myEvents}

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -1,6 +1,8 @@
 import { Avatar, Button, Card, Col, PageHeader, Row } from "antd";
+import useSWR from "swr";
 import Schedule from "./schedule";
 import { Queue } from "../../common/index";
+import { API } from "@template/api-client";
 import { MOCK_GET_COURSE_RESPONSE } from "../../server/src/mocks/getCourse";
 
 const Navbar = () => {
@@ -34,6 +36,10 @@ const QueueCard = ({ queue }: QueueCardProps) => {
 };
 
 export default function Today() {
+  const { data, error } = useSWR(`api/v1/courses/1/queue`, async () =>
+    console.log("queues", API.course.queues(1))
+  );
+
   const isTA = true;
 
   // TODO: this is currently mock data

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -1,67 +1,88 @@
-import { Avatar, Button, Card, Col, PageHeader, Row } from "antd";
+import { Avatar, Button, Card, Col, PageHeader, Row, Result } from "antd";
 import useSWR from "swr";
 import Schedule from "./schedule";
-import { Queue } from "../../common/index";
+import { Queue, QueuePartial } from "../../common/index";
 import { API } from "@template/api-client";
 import { MOCK_GET_COURSE_RESPONSE } from "../../server/src/mocks/getCourse";
 
 const Navbar = () => {
-  return <PageHeader title={"Khoury Office Hours"}>Wakanda Forever</PageHeader>;
+  return (
+    <PageHeader title={"Khoury Office Hours"}>
+      <h1>CS 2500</h1>
+    </PageHeader>
+  );
 };
 
 type QueueCardProps = {
-  queue: Queue;
+  queue: QueuePartial;
 };
 
 const QueueCard = ({ queue }: QueueCardProps) => {
   const staffList = queue.staffList;
   return (
-    <Card
-      title={staffList.map((staffMember) => staffMember.name).join(", ")}
-      extra={
-        <Button type="primary" size={"small"}>
-          Join Queue
-        </Button>
-      }
-      style={{ float: "left" }}
-    >
-      <p>{queue.room}</p>
-      {staffList.map((staffMember) => (
-        <div style={{ float: "left" }}>
-          <Avatar size={128} src={staffMember.photoURL} />
-        </div>
-      ))}
-    </Card>
+    <div style={{ padding: "25px 15px 25px 15px" }}>
+      <Card
+        title={staffList.map((staffMember) => staffMember.name).join(", ")}
+        extra={
+          <Button type="primary" size={"middle"}>
+            Join Queue
+          </Button>
+        }
+      >
+        <h1>{queue.room}</h1>
+        {staffList.map((staffMember) => (
+          <div style={{ float: "left", padding: "0px 25px 0px 25px" }}>
+            <Avatar size={128} src={staffMember.photoURL} shape="square" />
+          </div>
+        ))}
+      </Card>
+    </div>
   );
 };
 
 export default function Today() {
   const { data, error } = useSWR(`api/v1/courses/1/queue`, async () =>
-    console.log("queues", API.course.queues(1))
+    API.course.queues(1)
   );
 
-  const isTA = true;
+  const isTA = true; // TODO: temp
 
-  // TODO: this is currently mock data
+  if (error) {
+    return (
+      <Result
+        status="500"
+        title="Something went wrong, please ask chinese man"
+      />
+    );
+  }
+
   return (
     <div>
       <Navbar />
       <Row>
-        <Col span={12}>
-          {MOCK_GET_COURSE_RESPONSE.queues.map((q) => (
+        <Col md={12} sm={24}>
+          {data?.map((q) => (
             <QueueCard queue={q} />
           ))}
           {isTA ? (
-            <Button
-              style={{ bottom: "0%", width: "100%" }}
-              type="default"
-              size={"large"}
-            >
-              Create Queue
-            </Button>
+            <div style={{ padding: "0px 15px 0px 0px" }}>
+              <Button
+                style={{
+                  bottom: "0%",
+                  width: "20%",
+                  float: "right",
+                  backgroundColor: "#4cbb17",
+                  color: "white",
+                }}
+                type="default"
+                size={"large"}
+              >
+                Create Queue
+              </Button>
+            </div>
           ) : null}
         </Col>
-        <Col span={12}>
+        <Col md={12} sm={24}>
           <Schedule viewType={"day"} />
         </Col>
       </Row>

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -1,6 +1,7 @@
-import { Card, PageHeader } from "antd";
+import { Avatar, Button, Card, Col, PageHeader, Row } from "antd";
 import Schedule from "./schedule";
 import { Queue } from "../../common/index";
+import { MOCK_GET_COURSE_RESPONSE } from "../../server/src/mocks/getCourse";
 
 const Navbar = () => {
   return <PageHeader title={"Khoury Office Hours"}>Wakanda Forever</PageHeader>;
@@ -11,31 +12,53 @@ type QueueCardProps = {
 };
 
 const QueueCard = ({ queue }: QueueCardProps) => {
-  const staffList = queue.staffList.join(" ");
-
+  const staffList = queue.staffList;
   return (
     <Card
-      title={queue.room}
-      extra={<a href="#">Join Queue</a>} // todo: make this a button or something idk
-      style={{ width: 300 }}
+      title={staffList.map((staffMember) => staffMember.name).join(", ")}
+      extra={
+        <Button type="primary" size={"small"}>
+          Join Queue
+        </Button>
+      }
+      style={{ float: "left" }}
     >
-      <p>{staffList}</p>
-      <p>pictures</p>
-      <p>something else</p>
+      <p>{queue.room}</p>
+      {staffList.map((staffMember) => (
+        <div style={{ float: "left" }}>
+          <Avatar size={128} src={staffMember.photoURL} />
+        </div>
+      ))}
     </Card>
   );
 };
 
 export default function Today() {
+  const isTA = true;
+
+  // TODO: this is currently mock data
   return (
     <div>
       <Navbar />
-      <div>
-        <p>Lorem Ipsum</p>
-      </div>
-      <div style={{ float: "right" }}>
-        <Schedule viewType={"day"} />
-      </div>
+      <Row>
+        <Col span={12}>
+          {MOCK_GET_COURSE_RESPONSE.queues.map((q) => (
+            <QueueCard queue={q} />
+          ))}
+          {isTA ? (
+            <Button
+              style={{ bottom: "0%", width: "100%" }}
+              type="default"
+              size={"large"}
+            >
+              Create Queue
+            </Button>
+          ) : null}
+        </Col>
+        <Col span={12}>
+          <Schedule viewType={"day"} />
+        </Col>
+      </Row>
     </div>
   );
 }

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -43,11 +43,11 @@ export default function Today() {
           {data?.map((q) => (
             <OpenQueueCard key={q.id} queue={q} />
           ))}
-          {isTA ? (
+          {isTA && (
             <CreateQueueButton type="default" size={"large"}>
               Create Queue
             </CreateQueueButton>
-          ) : null}
+          )}
         </Col>
         <Col md={12} sm={24}>
           <Schedule viewType={"day"} />

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -14,8 +14,6 @@ const Navbar = () => {
 };
 
 const CreateQueueButton = styled(Button)`
-  bottom: 0%;
-  width: 20%;
   float: right;
   background-color: #4cbb17;
   color: white;
@@ -41,7 +39,7 @@ export default function Today() {
     <div>
       <Navbar />
       <Row gutter={25}>
-        <Col md={12} sm={24}>
+        <Col md={12} xs={24}>
           {data?.map((q) => (
             <OpenQueueCard key={q.id} queue={q} />
           ))}

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -1,0 +1,41 @@
+import { Card, PageHeader } from "antd";
+import Schedule from "./schedule";
+import { Queue } from "../../common/index";
+
+const Navbar = () => {
+  return <PageHeader title={"Khoury Office Hours"}>Wakanda Forever</PageHeader>;
+};
+
+type QueueCardProps = {
+  queue: Queue;
+};
+
+const QueueCard = ({ queue }: QueueCardProps) => {
+  const staffList = queue.staffList.join(" ");
+
+  return (
+    <Card
+      title={queue.room}
+      extra={<a href="#">Join Queue</a>} // todo: make this a button or something idk
+      style={{ width: 300 }}
+    >
+      <p>{staffList}</p>
+      <p>pictures</p>
+      <p>something else</p>
+    </Card>
+  );
+};
+
+export default function Today() {
+  return (
+    <div>
+      <Navbar />
+      <div>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div style={{ float: "right" }}>
+        <Schedule viewType={"day"} />
+      </div>
+    </div>
+  );
+}

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -3,7 +3,7 @@ import useSWR from "swr";
 import Schedule from "./schedule";
 import { Queue, QueuePartial } from "../../common/index";
 import { API } from "@template/api-client";
-import { MOCK_GET_COURSE_RESPONSE } from "../../server/src/mocks/getCourse";
+import styled from "styled-components";
 
 const Navbar = () => {
   return (
@@ -17,26 +17,42 @@ type QueueCardProps = {
   queue: QueuePartial;
 };
 
+const PaddedCard = styled(Card)`
+  margin-bottom: 25px;
+`;
+
+const AvatarContainer = styled.div`
+  padding-left: 25px;
+  padding-right: 25px;
+  float: left;
+`;
+
+const CreateQueueButton = styled(Button)`
+  bottom: 0%;
+  width: 20%;
+  float: right;
+  background-color: #4cbb17;
+  color: white;
+`;
+
 const QueueCard = ({ queue }: QueueCardProps) => {
   const staffList = queue.staffList;
   return (
-    <div style={{ padding: "25px 15px 25px 15px" }}>
-      <Card
-        title={staffList.map((staffMember) => staffMember.name).join(", ")}
-        extra={
-          <Button type="primary" size={"middle"}>
-            Join Queue
-          </Button>
-        }
-      >
-        <h1>{queue.room}</h1>
-        {staffList.map((staffMember) => (
-          <div style={{ float: "left", padding: "0px 25px 0px 25px" }}>
-            <Avatar size={128} src={staffMember.photoURL} shape="square" />
-          </div>
-        ))}
-      </Card>
-    </div>
+    <PaddedCard
+      title={staffList.map((staffMember) => staffMember.name).join(", ")}
+      extra={
+        <Button type="primary" size={"middle"}>
+          Join Queue
+        </Button>
+      }
+    >
+      <h1>{queue.room}</h1>
+      {staffList.map((staffMember) => (
+        <AvatarContainer key={staffMember.id}>
+          <Avatar size={128} src={staffMember.photoURL} shape="square" />
+        </AvatarContainer>
+      ))}
+    </PaddedCard>
   );
 };
 
@@ -59,27 +75,15 @@ export default function Today() {
   return (
     <div>
       <Navbar />
-      <Row>
+      <Row gutter={25}>
         <Col md={12} sm={24}>
           {data?.map((q) => (
-            <QueueCard queue={q} />
+            <QueueCard key={q.id} queue={q} />
           ))}
           {isTA ? (
-            <div style={{ padding: "0px 15px 0px 0px" }}>
-              <Button
-                style={{
-                  bottom: "0%",
-                  width: "20%",
-                  float: "right",
-                  backgroundColor: "#4cbb17",
-                  color: "white",
-                }}
-                type="default"
-                size={"large"}
-              >
-                Create Queue
-              </Button>
-            </div>
+            <CreateQueueButton type="default" size={"large"}>
+              Create Queue
+            </CreateQueueButton>
           ) : null}
         </Col>
         <Col md={12} sm={24}>

--- a/packages/app/pages/today.tsx
+++ b/packages/app/pages/today.tsx
@@ -1,9 +1,9 @@
-import { Avatar, Button, Card, Col, PageHeader, Row, Result } from "antd";
+import { Button, Col, PageHeader, Row, Result } from "antd";
 import useSWR from "swr";
 import Schedule from "./schedule";
-import { Queue, QueuePartial } from "../../common/index";
 import { API } from "@template/api-client";
 import styled from "styled-components";
+import OpenQueueCard from "../components/Today/OpenQueueCard";
 
 const Navbar = () => {
   return (
@@ -13,20 +13,6 @@ const Navbar = () => {
   );
 };
 
-type QueueCardProps = {
-  queue: QueuePartial;
-};
-
-const PaddedCard = styled(Card)`
-  margin-bottom: 25px;
-`;
-
-const AvatarContainer = styled.div`
-  padding-left: 25px;
-  padding-right: 25px;
-  float: left;
-`;
-
 const CreateQueueButton = styled(Button)`
   bottom: 0%;
   width: 20%;
@@ -34,27 +20,6 @@ const CreateQueueButton = styled(Button)`
   background-color: #4cbb17;
   color: white;
 `;
-
-const QueueCard = ({ queue }: QueueCardProps) => {
-  const staffList = queue.staffList;
-  return (
-    <PaddedCard
-      title={staffList.map((staffMember) => staffMember.name).join(", ")}
-      extra={
-        <Button type="primary" size={"middle"}>
-          Join Queue
-        </Button>
-      }
-    >
-      <h1>{queue.room}</h1>
-      {staffList.map((staffMember) => (
-        <AvatarContainer key={staffMember.id}>
-          <Avatar size={128} src={staffMember.photoURL} shape="square" />
-        </AvatarContainer>
-      ))}
-    </PaddedCard>
-  );
-};
 
 export default function Today() {
   const { data, error } = useSWR(`api/v1/courses/1/queue`, async () =>
@@ -78,7 +43,7 @@ export default function Today() {
       <Row gutter={25}>
         <Col md={12} sm={24}>
           {data?.map((q) => (
-            <QueueCard key={q.id} queue={q} />
+            <OpenQueueCard key={q.id} queue={q} />
           ))}
           {isTA ? (
             <CreateQueueButton type="default" size={"large"}>

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -29,6 +29,8 @@ export interface GetCourseResponse {
   queues?: Queue[];
 }
 
+export type GetCourseQueuesResponse = QueuePartial[];
+
 export type ListQuestionsResponse = Question[];
 
 export type GetQuestionResponse = Question;
@@ -158,6 +160,24 @@ export interface Queue {
 }
 
 /**
+ * A Queue partial to be shown on the today page.
+ * @param id - The unique id number for a Queue.
+ * @param room - The full name of the building + room # that the current office hours queue is in.
+ * @param createdAt - The date string for the opened on time (aka created on time) of this queue of this queue. Ex: "2019-09-21T12:00:00-04:00"
+ * @param closedAt - The date string for the the closed on time for the queue.
+ * @param staffList - The list of TA user's that are currently helping at office hours.
+ */
+export interface QueuePartial {
+  id: number;
+  room: string;
+  createdAt: Date;
+  closedAt?: Date;
+  staffList: UserPartial[];
+  queueSize: number;
+  // TODO: Add wait time?
+}
+
+/**
  * A Question is created when a student wants help from a TA.
  * @param id - The unique id number for a student question.
  * @param creator - The Student that has created the question.
@@ -198,6 +218,12 @@ type QuestionStatus =
   | "Deferred"
   | "No Show"
   | "Deleted";
+
+export enum OpenQuestionStatus {
+  Drafting = "Drafting",
+  Queued = "Queued",
+  Helping = "Helping",
+}
 
 /**
  * A Semester object, representing a schedule semester term for the purposes of a course.

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -210,19 +210,19 @@ export enum QuestionType {
 }
 
 // Ticket Status - Represents a given status of as student's ticket
-type QuestionStatus =
-  | "Drafting"
-  | "Queued"
-  | "Helping"
-  | "Resolved"
-  | "Deferred"
-  | "No Show"
-  | "Deleted";
+type QuestionStatus = OpenQuestionStatus | ClosedQuestionStatus;
 
 export enum OpenQuestionStatus {
   Drafting = "Drafting",
   Queued = "Queued",
   Helping = "Helping",
+}
+
+export enum ClosedQuestionStatus {
+  Resolved = "Resolved",
+  Deferred = "Deferred",
+  NoShow = "No Show",
+  Deleted = "Deleted",
 }
 
 /**

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -210,7 +210,7 @@ export enum QuestionType {
 }
 
 // Ticket Status - Represents a given status of as student's ticket
-type QuestionStatus = OpenQuestionStatus | ClosedQuestionStatus;
+export type QuestionStatus = OpenQuestionStatus | ClosedQuestionStatus;
 
 export enum OpenQuestionStatus {
   Drafting = "Drafting",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -147,7 +147,7 @@ interface OfficeHourBlock {
  * @param staffList - The list of TA user's that are currently helping at office hours.
  * @param questions - The list of the students questions assocaited with the queue.
  */
-interface Queue {
+export interface Queue {
   id: number;
   course: CoursePartial;
   room: string;

--- a/packages/server/src/api/courseRoutes.ts
+++ b/packages/server/src/api/courseRoutes.ts
@@ -1,8 +1,8 @@
 import { ServerRoute, ResponseObject } from "@hapi/hapi";
 import Joi from "@hapi/joi";
-import { CourseSchema, QueueSchema } from "../joi";
+import { CourseSchema, QueueSchema, CourseQueueSchema } from "../joi";
 import { CourseModel } from "../entity/CourseModel";
-import { pick } from "lodash";
+import { pick, cloneDeep } from "lodash";
 import {
   TAUpdateStatusParams,
   TAUpdateStatusResponse,
@@ -41,18 +41,20 @@ export const courseRoutes: ServerRoute[] = [
     method: "GET",
     path: "/api/v1/courses/{course_id}/queues",
     handler: async (request, h): Promise<GetCourseQueuesResponse> => {
-      const queuesResponse = { ...MOCK_GET_COURSE_RESPONSE.queues };
+      const queuesResponse = cloneDeep(MOCK_GET_COURSE_RESPONSE.queues);
+
       queuesResponse.forEach(
         (queue) =>
-          (queue["queueSize"] = queue.questions.filter((question) =>
-            Object.values(OpenQuestionStatus).includes(question.status)
+          (queue["queueSize"] = queue.questions.filter(
+            (question) => question.status in OpenQuestionStatus
           ).length)
       );
-      return queuesResponse.map((queue) =>
+
+      return queuesResponse.map((queue: any) =>
         pick(queue, [
           "id",
           "room",
-          "createAt",
+          "createdAt",
           "closedAt",
           "staffList",
           "queueSize",
@@ -61,7 +63,7 @@ export const courseRoutes: ServerRoute[] = [
     },
     options: {
       response: {
-        schema: CourseSchema.options({ presence: "required" }),
+        schema: CourseQueueSchema.options({ presence: "required" }),
       },
     },
   },

--- a/packages/server/src/api/courseRoutes.ts
+++ b/packages/server/src/api/courseRoutes.ts
@@ -7,16 +7,19 @@ import {
   TAUpdateStatusParams,
   TAUpdateStatusResponse,
   GetCourseResponse,
+  GetCourseQueuesResponse,
+  OpenQuestionStatus,
 } from "@template/common";
 import {
   MOCK_TA_UPDATE_STATUS_ARRIVED_RESPONSE,
   MOCK_TA_UPDATE_STATUS_DEPARTED_RESPONSE,
 } from "../mocks/taUpdateStatus";
+import { MOCK_GET_COURSE_RESPONSE } from "../mocks/getCourse";
 
 export const courseRoutes: ServerRoute[] = [
   {
     method: "GET",
-    path: "/api/v1/courses/{course_id}",
+    path: "/api/v1/courses/{course_id}/schedule",
     handler: async (request, h): Promise<GetCourseResponse> => {
       const course = await CourseModel.findOne(request.params.course_id, {
         relations: ["officeHours"],
@@ -27,6 +30,34 @@ export const courseRoutes: ServerRoute[] = [
           pick(e, ["id", "title", "room", "startTime", "endTime"])
         ),
       };
+    },
+    options: {
+      response: {
+        schema: CourseSchema.options({ presence: "required" }),
+      },
+    },
+  },
+  {
+    method: "GET",
+    path: "/api/v1/courses/{course_id}/queues",
+    handler: async (request, h): Promise<GetCourseQueuesResponse> => {
+      const queuesResponse = { ...MOCK_GET_COURSE_RESPONSE.queues };
+      queuesResponse.forEach(
+        (queue) =>
+          (queue["queueSize"] = queue.questions.filter((question) =>
+            Object.values(OpenQuestionStatus).includes(question.status)
+          ).length)
+      );
+      return queuesResponse.map((queue) =>
+        pick(queue, [
+          "id",
+          "room",
+          "createAt",
+          "closedAt",
+          "staffList",
+          "queueSize",
+        ])
+      );
     },
     options: {
       response: {

--- a/packages/server/src/joi.ts
+++ b/packages/server/src/joi.ts
@@ -86,3 +86,14 @@ export const CourseSchema = Joi.object({
   officeHours: Joi.array().items(OfficeHourBlockSchema),
   // queues: Joi.array().items(QueueSchema),
 });
+
+export const CourseQueueSchema = Joi.array().items(
+  Joi.object({
+    id: Joi.number(),
+    room: Joi.string(),
+    createdAt: Joi.date(),
+    closedAt: Joi.date().allow(null),
+    staffList: Joi.array().items(UserPartialSchema),
+    queueSize: Joi.number(),
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,6 +1837,14 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-big-calendar@^0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@types/react-big-calendar/-/react-big-calendar-0.24.2.tgz#527c7923db6c88d5c96b63351966957b49326052"
+  integrity sha512-rjr3IfBIIkPy5n4Jc4PAcPqPtYMq1OR2WpK7PZD9MeDi7W8mh8nKG87LqHAcVhfY05xs5xvZXLlBpobVvp0DyQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react-dom@*":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"


### PR DESCRIPTION
We:

- created the today page :) (and kinda on mobile but not really but at least it stacks 🥳 )
- created the endpoint /v1/courses/{course_id}/queue
- moved /v1/courses/{course_id}/ -> same but with schedule at the end
- removed the title header from the calendar because the navbar will have it one day
- made a temp navbar
- made some probably questionable frontend maneuvers. pls guide us senpai
- updated some types but ignore `yarn tsc`