### PR TITLE
Open Microsoft Teams chat when helping a student

### DIFF
--- a/packages/app/components/Queue/StudentInfoCard.tsx
+++ b/packages/app/components/Queue/StudentInfoCard.tsx
@@ -89,7 +89,7 @@ const StudentInfoCard = ({
       title={
         <Row justify="space-between">
           <Name>{question.creator.name}</Name>
-          <Email>takayama.a@northeastern.edu</Email>
+          <Email>{question.creator.email}</Email>
         </Row>
       }
     >

--- a/packages/app/components/Queue/StudentPopupCard.tsx
+++ b/packages/app/components/Queue/StudentPopupCard.tsx
@@ -86,7 +86,6 @@ const BodyText = styled.div`
 interface StudentPopupCardProps {
   updateQuestion: (question: Question, status: QuestionStatus) => void;
   onClose: () => void;
-  email: string;
   wait: number;
   visible: boolean;
   question: Question;
@@ -96,7 +95,6 @@ interface StudentPopupCardProps {
 const StudentPopupCard = ({
   updateQuestion,
   onClose,
-  email,
   wait,
   question,
   visible,
@@ -134,9 +132,14 @@ const StudentPopupCard = ({
             <Button
               block
               type="primary"
-              onClick={() =>
-                updateQuestion(question, OpenQuestionStatus.Helping)
-              }
+              onClick={() => {
+                updateQuestion(question, OpenQuestionStatus.Helping);
+                if (question.online) {
+                  window.open(
+                    `https://teams.microsoft.com/l/chat/0/0?users=${question.creator.email}`
+                  );
+                }
+              }}
               disabled={!isStaffCheckedIn}
             >
               Help

--- a/packages/app/components/Queue/StudentPopupCard.tsx
+++ b/packages/app/components/Queue/StudentPopupCard.tsx
@@ -88,7 +88,6 @@ interface StudentPopupCardProps {
   onClose: () => void;
   email: string;
   wait: number;
-  location: string;
   visible: boolean;
   question: Question;
   isStaffCheckedIn: boolean;
@@ -99,7 +98,6 @@ const StudentPopupCard = ({
   onClose,
   email,
   wait,
-  location,
   question,
   visible,
   isStaffCheckedIn,
@@ -152,7 +150,7 @@ const StudentPopupCard = ({
 
         <InfoTextDiv>
           <Title>{question.creator.name}</Title>
-          <Email>{email}</Email>
+          <Email>{question.creator.email}</Email>
         </InfoTextDiv>
 
         <StatusTag color="purple">{question.status}</StatusTag>
@@ -174,7 +172,9 @@ const StudentPopupCard = ({
         </FullWidth>
         <FullWidth>
           <HeadingText>location</HeadingText>
-          <BodyText>{location}</BodyText>
+          <BodyText>
+            {question.location || (question.online && "Online")}
+          </BodyText>
         </FullWidth>
       </Container>
     </Drawer>

--- a/packages/app/components/Queue/TAQueueList.tsx
+++ b/packages/app/components/Queue/TAQueueList.tsx
@@ -361,7 +361,7 @@ export default function TAQueueList({
       {currentQuestion && (
         <StudentPopupCard
           onClose={onCloseClick}
-          email="takayama.a@northeastern.edu" //need a way to access this. or the user
+          email={currentQuestion.creator.email} //need a way to access this. or the user
           wait={20} //figure out later
           question={currentQuestion}
           location="Outside by the printer" // need a way to access this

--- a/packages/app/components/Queue/TAQueueList.tsx
+++ b/packages/app/components/Queue/TAQueueList.tsx
@@ -361,10 +361,8 @@ export default function TAQueueList({
       {currentQuestion && (
         <StudentPopupCard
           onClose={onCloseClick}
-          email={currentQuestion.creator.email} //need a way to access this. or the user
           wait={20} //figure out later
           question={currentQuestion}
-          location="Outside by the printer" // need a way to access this
           visible={openPopup}
           updateQuestion={updateQuestionTA}
           isStaffCheckedIn={isStaffCheckedIn}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -39,6 +39,7 @@ export type User = {
  */
 export type UserPartial = {
   id: number;
+  email: string;
   name: string;
   photoURL?: string;
 };

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -168,6 +168,8 @@ export type Question = {
   closedAt?: Date;
   questionType?: QuestionType;
   status: QuestionStatus;
+  location?: string;
+  online?: boolean;
 };
 
 // Question Types

--- a/packages/server/fixtures/questionModel.yml
+++ b/packages/server/fixtures/questionModel.yml
@@ -7,3 +7,12 @@ items:
     questionType: 'Other'
     status: 'Queued'
     creatorId: '@user0'
+    location: 'behind the couches'
+  question1:
+    queueId: '@queue0'
+    text: 'What is abstraction'
+    createdAt: '{{date.recent}}'
+    questionType: 'Concept'
+    status: 'Queued'
+    creatorId: '@user3'
+    online: true

--- a/packages/server/fixtures/userCourseModel.yml
+++ b/packages/server/fixtures/userCourseModel.yml
@@ -12,3 +12,7 @@ items:
     userId: '@user2'
     courseId: '@course0'
     role: 'student'
+  ucm3:
+    userId: '@user3'
+    courseId: '@course0'
+    role: 'student'

--- a/packages/server/fixtures/userModel.yml
+++ b/packages/server/fixtures/userModel.yml
@@ -17,6 +17,6 @@ items:
     photoURL: 'https://i.imgur.com/iyQyUiN.jpeg'
   user3:
     username: 'online_user'
-    email: 'online@husky.neu.edu'
+    email: 'chu.daj@northeastern.edu'
     name: 'NU Flex'
     photoURL: 'https://i.imgur.com/iyQyUiN.jpeg'

--- a/packages/server/fixtures/userModel.yml
+++ b/packages/server/fixtures/userModel.yml
@@ -15,3 +15,8 @@ items:
     email: 'liu.sta@husky.neu.edu'
     name: 'Stanley Liu'
     photoURL: 'https://i.imgur.com/iyQyUiN.jpeg'
+  user3:
+    username: 'online_user'
+    email: 'online@husky.neu.edu'
+    name: 'NU Flex'
+    photoURL: 'https://i.imgur.com/iyQyUiN.jpeg'

--- a/packages/server/src/profile/user.entity.ts
+++ b/packages/server/src/profile/user.entity.ts
@@ -22,7 +22,6 @@ export class UserModel extends BaseEntity {
   username: string;
 
   @Column('text')
-  @Exclude()
   email: string;
 
   @Column('text')

--- a/packages/server/src/question/question.entity.ts
+++ b/packages/server/src/question/question.entity.ts
@@ -60,4 +60,10 @@ export class QuestionModel extends BaseEntity {
 
   @Column('text')
   status: QuestionStatus;
+
+  @Column({ nullable: true })
+  location: string;
+
+  @Column({ nullable: true })
+  online: boolean;
 }

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -25,6 +25,7 @@ Object {
   "room": "WVH 101",
   "staffList": Array [
     Object {
+      "email": "user1@neu.edu",
       "id": 1,
       "name": "John Doe the 1th",
       "photoURL": "https://pics/1",

--- a/packages/server/test/__snapshots__/question.integration.ts.snap
+++ b/packages/server/test/__snapshots__/question.integration.ts.snap
@@ -5,6 +5,7 @@ Object {
   "closedAt": null,
   "createdAt": "2020-03-01T05:00:00.000Z",
   "creator": Object {
+    "email": "user1@neu.edu",
     "id": 1,
     "name": "John Doe the 1th",
     "photoURL": "https://pics/1",

--- a/packages/server/test/__snapshots__/question.integration.ts.snap
+++ b/packages/server/test/__snapshots__/question.integration.ts.snap
@@ -12,6 +12,8 @@ Object {
   },
   "helpedAt": null,
   "id": 1,
+  "location": null,
+  "online": null,
   "questionType": "Other",
   "status": "Queued",
   "taHelped": null,

--- a/packages/server/test/__snapshots__/queue.integration.ts.snap
+++ b/packages/server/test/__snapshots__/queue.integration.ts.snap
@@ -23,6 +23,8 @@ Array [
     },
     "helpedAt": null,
     "id": 1,
+    "location": null,
+    "online": null,
     "questionType": "Other",
     "status": "Queued",
     "taHelped": null,

--- a/packages/server/test/__snapshots__/queue.integration.ts.snap
+++ b/packages/server/test/__snapshots__/queue.integration.ts.snap
@@ -16,6 +16,7 @@ Array [
     "closedAt": null,
     "createdAt": "2020-03-01T05:00:00.000Z",
     "creator": Object {
+      "email": "user2@neu.edu",
       "id": 1,
       "name": "John Doe the 2th",
       "photoURL": "https://pics/2",


### PR DESCRIPTION
This PR makes some changes to UserModel and QuestionModel that we were missing before, if I messed up anything Nest-wise pls lmk. I made it so that if a question is marked as online, clicking Help will automatically open a chat with the student, but this behavior can be changed easily.

To test:
1. Seed the database
2. Login as TA
3. Click on second question in queue
4. Click help

Closes #51 