### PR TITLE
Fix 3rd in Queue Notif Error

### DIFF
--- a/packages/server/src/question/question.subscriber.ts
+++ b/packages/server/src/question/question.subscriber.ts
@@ -53,7 +53,7 @@ export class QuestionSubscriber
         .setQueryRunner(event.queryRunner) // Run in same transaction as the update
         .offset(2)
         .getOne();
-      if (previousThird?.id !== third?.id) {
+      if (third && previousThird?.id !== third?.id) {
         const { creatorId } = third;
         this.notifService.notifyUser(creatorId, NotifMsgs.queue.THIRD_PLACE);
       }


### PR DESCRIPTION
When you go from 3 people in the queue, to 2 people in the queue, the subscriber throws an error because `third` is undefined.