### PR TITLE
Remove unnecessary db query

### DIFF
--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -19,8 +19,6 @@ export class QueueService {
 
     await queue.addQueueTimes();
     await queue.checkIsOpen();
-    const questions = await QuestionModel.find({ where: { queueId } });
-    queue.questions = questions;
 
     return queue;
   }


### PR DESCRIPTION
Looks like we don't need this query. 

Getting questions for the queue comes from the `/queues/:queue_id/questions` endpoint