### PR TITLE
Attempt to Speed up GitHub Actions by Caching node_modules

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn build
       - name: Cypress run
         uses: cypress-io/github-action@v2

--- a/.github/workflows/enforce-migration.yml
+++ b/.github/workflows/enforce-migration.yml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - name: Check is Migration Needed
         run: .github/scripts/isMigrationNeeded.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn pretty-quick --branch master --check
   lint:
     name: lint
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn lint
   typescript:
     name: typescript
@@ -34,5 +34,5 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn tsc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,5 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: yarn install
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - if: steps.yyarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - if: steps.yyarn-cache.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
       - run: yarn test


### PR DESCRIPTION
Using https://github.com/marketplace/actions/npm-or-yarn-install-with-caching to leverage the GitHub Actions cache on yarn install. Brings `yarn install` time on Actions from ~1m20s to ~50s. It's not a huge leap because we still end up linking dependencies. Not sure if that can be skipped, but a 30s speedup on all actions may help us deploy quick and more confidently during incidents.