### PR TITLE
Push Built Files to Deployment Targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Staging
 on:
   push:
     branches:
-      - dc-build-on-gh
+      - master
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
       - name: "set git bot commiter"
         run: git config --global user.name "KOH Build Bot" && git config --global user.email "bot@khouryofficehours.com"
       - name: "merge new changes into dist"
-        run: git merge origin/dc-build-on-gh
+        run: git merge origin/master
       - uses: bahmutov/npm-install@v1
       - run: yarn build
       - uses: EndBug/add-and-commit@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build Dist Branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,5 +42,6 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - uses: actions/checkout@v2
       - name: "pm2 deploy to staging"
         run: "npx pm2 deploy infrastructure/prod/ecosystem.config.js staging update"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,15 +6,9 @@ on:
       - dc-build-on-gh
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - uses: actions/checkout@v2
         with:
           ref: 'dist'
@@ -37,6 +31,15 @@ jobs:
           ref: 'dist'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: git status
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - name: "pm2 deploy to staging"
         run: "npx pm2 deploy infrastructure/prod/ecosystem.config.js staging update"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,15 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - uses: actions/checkout@v2
+        with:
+          ref: 'dist'
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
+      - run: git merge master
       - run: yarn install
       - run: yarn build
-      - run: git checkout dist
       - uses: EndBug/add-and-commit@v4
         with:
           add: 'packages'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
-      - run: git merge origin/master
+      - run: git merge origin/dc-build-on-gh
       - run: yarn install
       - run: yarn build
       - uses: EndBug/add-and-commit@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
-      - run: git merge master
+      - run: git merge origin/master
       - run: yarn install
       - run: yarn build
       - uses: EndBug/add-and-commit@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: "12"
       - run: yarn install
       - run: yarn build
+      - run: git checkout dist
       - uses: EndBug/add-and-commit@v4
         with:
           add: 'packages'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: git config --global user.name "KOH Build Bot" && git config --global user.email "bot@khouryofficehours.com"
       - name: "merge new changes into dist"
         run: git merge origin/dc-build-on-gh
-      - run: yarn install
+      - uses: bahmutov/npm-install@v1
       - run: yarn build
       - uses: EndBug/add-and-commit@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
-      - run: git merge origin/dc-build-on-gh
+      - name: "set git bot commiter"
+        run: git config --global user.name "KOH Build Bot" && git config --global user.email "bot@khouryofficehours.com"
+      - name: "merge new changes into dist"
+        run: git merge origin/dc-build-on-gh
       - run: yarn install
       - run: yarn build
       - uses: EndBug/add-and-commit@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,13 @@ jobs:
       - run: yarn build
       - uses: EndBug/add-and-commit@v4
         with:
+          add: 'packages'
           author_name: KOH Build Bot
           author_email: bot@khouryofficehours.com
-          force: true
           message: 'Added built files'
           ref: 'dist'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: git status
       - name: "pm2 deploy to staging"
         run: "npx pm2 deploy infrastructure/prod/ecosystem.config.js staging update"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Staging
 on:
   push:
     branches:
-      - master
+      - dc-build-on-gh
 
 jobs:
   deploy:
@@ -19,5 +19,16 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12"
+      - run: yarn install
+      - run: yarn build
+      - uses: EndBug/add-and-commit@v4
+        with:
+          author_name: KOH Build Bot
+          author_email: bot@khouryofficehours.com
+          force: true
+          message: 'Added built files'
+          ref: 'dist'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "pm2 deploy to staging"
         run: "npx pm2 deploy infrastructure/prod/ecosystem.config.js staging update"

--- a/infrastructure/prod/ecosystem.config.js
+++ b/infrastructure/prod/ecosystem.config.js
@@ -23,12 +23,12 @@ module.exports = {
     staging: {
       user: "ubuntu",
       host: "128.31.24.252",
-      ref: "origin/master",
+      ref: "origin/dist",
       repo: "https://github.com/sandboxnu/office-hours.git",
       path: "/var/www",
       "pre-deploy-local": "",
       "post-deploy":
-        "yarn && yarn build && yarn typeorm migration:run && yarn prod:start",
+        "yarn && yarn typeorm migration:run && yarn prod:start",
       "pre-setup": "",
     },
     production: {

--- a/packages/app/pages/dev.tsx
+++ b/packages/app/pages/dev.tsx
@@ -61,7 +61,7 @@ export default function DevPanel({ hidePage }: DevPanelProps): ReactElement {
   return (
     <Container>
       <h1>
-        <PageHeader>hello[ For Development Use Only ]</PageHeader>
+        <PageHeader>[ For Development Use Only ]</PageHeader>
       </h1>
       <LoginContainer>
         <Divider plain>

--- a/packages/app/pages/dev.tsx
+++ b/packages/app/pages/dev.tsx
@@ -61,7 +61,7 @@ export default function DevPanel({ hidePage }: DevPanelProps): ReactElement {
   return (
     <Container>
       <h1>
-        <PageHeader>[ For Development Use Only ]</PageHeader>
+        <PageHeader>hello[ For Development Use Only ]</PageHeader>
       </h1>
       <LoginContainer>
         <Divider plain>


### PR DESCRIPTION
Deploying to staging/prod can take 5-10 minutes. Most of this is running `yarn build` which is super slow on the VMs and can even affect webapp performance. Solution is to build first, then push the built files to where we want to deploy them. 

_(we could do this with docker, but it's much simpler this way)_

PM2 pulls down from git, so we're just gonna host the built files **on a Git branch**. 

## Primary Changes
1. The `dist` branch has a different `.gitignore` that lets the built js files get committed.
2. The `deploy` GitHub Action runs `yarn build` and commit/pushes the result to the `dist` branch
3. Then, the action runs pm2 deploy the same way as before, except `ecosystem.config.js` gets `dist` instead of `master`, and doesn't run build in the `pre-deploy`.

## How does this affect the deployment process?

You can no longer run `yarn deploy production` immediately after pushing to master. Check GitHub to make sure the `Deploy > Build Dist Branch` job passed so that the changes will be on `dist`.