### PR TITLE
Look for events with office hours keywords instead of the opposite

### DIFF
--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -44,8 +44,8 @@ export class IcalService {
     );
 
     const isOfficeHoursEvent = (title: string) => {
-      const nonOfficeHourKeywords = ['Lecture', 'Lab', 'Exam', 'Class'];
-      return nonOfficeHourKeywords.every(keyword => !title.includes(keyword));
+      const offficeHourKeywords = ['OH', 'Hours'];
+      return offficeHourKeywords.some(keyword => title.includes(keyword));
     };
 
     return officeHours

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -43,7 +43,7 @@ export class IcalService {
         iCalElement.end !== undefined,
     );
 
-    const officeHoursEventRegex = /\b(OH|Hours)\b/g;
+    const officeHoursEventRegex = /\b^(OH|Hours)\b/;
 
     return officeHours
       .filter(event => officeHoursEventRegex.test(event.summary))

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -43,13 +43,10 @@ export class IcalService {
         iCalElement.end !== undefined,
     );
 
-    const isOfficeHoursEvent = (title: string) => {
-      const offficeHourKeywords = ['OH', 'Hours'];
-      return offficeHourKeywords.some(keyword => title.includes(keyword));
-    };
+    const officeHoursEventRegex = /\b(OH|Hours)\b/g;
 
     return officeHours
-      .filter(event => isOfficeHoursEvent(event.summary))
+      .filter(event => officeHoursEventRegex.test(event.summary))
       .map(event => ({
         title: event.summary,
         courseId: courseId,


### PR DESCRIPTION
This will allow Ben Lerner and other professors to create events for their own separate office hours and not have to worry about it showing up in our application. 

Closes #321 