### PR TITLE
Fix "cannot read property split of undefined"

### DIFF
--- a/packages/app/components/common/AvatarWithInitials.tsx
+++ b/packages/app/components/common/AvatarWithInitials.tsx
@@ -17,7 +17,7 @@ export default function AvatarWithInitals({
   return (
     <Avatar
       style={{
-        backgroundColor: nameToRGB(name),
+        backgroundColor: name ? nameToRGB(name) : "#1abc9c",
         fontSize,
       }}
       {...props}


### PR DESCRIPTION
I defaulted to the first color when the name string is undefined, but if there's a cleaner way to do this lmk