### PR TITLE
Check if name is defined before calling match

### DIFF
--- a/packages/app/utils/NameUtils.ts
+++ b/packages/app/utils/NameUtils.ts
@@ -1,6 +1,9 @@
 export default function getInitialsFromName(name: string): string {
-  const initialsRegex = name.match(/\b\w/g) || [];
-  return (
-    (initialsRegex.shift() || "") + (initialsRegex.pop() || "")
-  ).toUpperCase();
+  if (name) {
+    const initialsRegex = name.match(/\b\w/g) || [];
+    return (
+      (initialsRegex.shift() || "") + (initialsRegex.pop() || "")
+    ).toUpperCase();
+  }
+  return "";
 }


### PR DESCRIPTION
I was seeing this error on Elastic APM so I thought this might fix it. 

![image](https://user-images.githubusercontent.com/33739155/93917354-e5fe3880-fcd8-11ea-99e6-00dc66b3f8a3.png)
