### PR TITLE
hide dev panel better

### DIFF
--- a/packages/app/pages/dev.tsx
+++ b/packages/app/pages/dev.tsx
@@ -45,17 +45,11 @@ const PageHeader = styled.div`
   margin-top: 40px;
 `;
 
-export const getStaticProps: GetStaticProps = async () => {
-  const hidePage = PROD_URL === process.env.DOMAIN;
-  return { props: { hidePage } };
-};
-
-interface DevPanelProps {
-  hidePage: boolean;
-}
-
-export default function DevPanel({ hidePage }: DevPanelProps): ReactElement {
-  if (hidePage) {
+export default function DevPanel(): ReactElement {
+  if (
+    typeof window === "undefined" ||
+    window?.location?.hostname === PROD_URL
+  ) {
     return <DefaultErrorPage statusCode={404} />;
   }
   return (


### PR DESCRIPTION
Hiding dev panel on client side instead of at build time because both staging and prod pull from the pre-built files in the `dist` branch, so there's no way to statically render the dev panel on staging but not on prod. This is fine as we don't care about having speedy static site optimization for a dev panel.