### PR TITLE
Better IsProd Checking

### DIFF
--- a/packages/app/components/Nav/Settings.tsx
+++ b/packages/app/components/Nav/Settings.tsx
@@ -1,4 +1,4 @@
-import { PROD_URL } from "@koh/common";
+import { isProd } from "@koh/common";
 import { Menu, Popover } from "antd";
 import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
@@ -23,7 +23,7 @@ export default function Settings(): ReactElement {
   const profile = useProfile();
   const [isNotifOpen, setIsNotifOpen] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const loginPath = PROD_URL === process.env.DOMAIN ? "/login" : "/dev";
+  const loginPath = isProd() ? "/login" : "/dev";
 
   return (
     <>

--- a/packages/app/pages/dev.tsx
+++ b/packages/app/pages/dev.tsx
@@ -1,11 +1,9 @@
 import React, { ReactElement } from "react";
 import { API } from "@koh/api-client";
-import Link from "next/link";
 import styled from "styled-components";
 import { Button, Divider } from "antd";
-import { GetStaticProps } from "next";
-import { PROD_URL } from "@koh/common";
 import DefaultErrorPage from "next/error";
+import { isProd } from "@koh/common";
 
 const Container = styled.div`
   width: auto;
@@ -46,10 +44,7 @@ const PageHeader = styled.div`
 `;
 
 export default function DevPanel(): ReactElement {
-  if (
-    typeof window === "undefined" ||
-    window?.location?.hostname === PROD_URL
-  ) {
+  if (isProd()) {
     return <DefaultErrorPage statusCode={404} />;
   }
   return (

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -12,6 +12,9 @@ import { Type } from "class-transformer";
 import "reflect-metadata";
 
 export const PROD_URL = "https://khouryofficehours.com";
+export const isProd = (): boolean =>
+  process.env.DOMAIN === PROD_URL ||
+  (typeof window !== "undefined" && window?.location?.origin === PROD_URL);
 
 /////////////////////////
 // API Base Data Types //

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -4,7 +4,7 @@ import * as cookieParser from 'cookie-parser';
 import * as morgan from 'morgan';
 import { AppModule } from './app.module';
 import { StripUndefinedPipe } from './stripUndefined.pipe';
-import { PROD_URL } from '@koh/common';
+import { isProd } from '@koh/common';
 import { ApmInterceptor } from './apm.interceptor';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -16,12 +16,12 @@ export async function bootstrap(hot: any): Promise<void> {
   app.setGlobalPrefix('api/v1');
   app.useGlobalInterceptors(new ApmInterceptor());
 
-  if (process.env.DOMAIN !== PROD_URL) {
+  if (isProd()) {
+    console.log(`Running production at ${process.env.DOMAIN}.`);
+  } else {
     console.log(
       `Running non-production at ${process.env.DOMAIN}. THIS MSG SHOULD NOT APPEAR ON PROD VM`,
     );
-  } else {
-    console.log(`Running production at ${process.env.DOMAIN}.`);
   }
   app.use(morgan('dev'));
   await app.listen(3002);

--- a/packages/server/src/non-production.guard.ts
+++ b/packages/server/src/non-production.guard.ts
@@ -1,11 +1,9 @@
 import { Injectable, CanActivate } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { PROD_URL } from '@koh/common';
+import { isProd } from '@koh/common';
 
 @Injectable()
 export class NonProductionGuard implements CanActivate {
-  constructor(private configService: ConfigService) {}
   canActivate(): boolean {
-    return this.configService.get('DOMAIN') !== PROD_URL;
+    return !isProd();
   }
 }


### PR DESCRIPTION
**READ THIS PR CAREFULLY**

If a boolean is miffed somewhere in this PR we may open up dev features into prod :| 

The goal here is to avoid the isProd logic being spread out everywhere and get it right, in one spot. Also *actually* hide the dev panel correctly.

I'm starting to think it might be better to have an isProd on the frontend and one on the backend, cause reading process.env inside `common` is just a bit scary. Would like people's thoughts!
