### PR TITLE
Per-Device Notifs

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -13,7 +13,7 @@ import {
   UpdateQuestionParams,
   UpdateQuestionResponse,
   UpdateQueueParams,
-  Question,
+  Question,, DesktopNotifPartial
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -103,7 +103,7 @@ class APIClient {
     desktop: {
       credentials: async (): Promise<string> =>
         this.req("GET", "/api/v1/notifications/desktop/credentials"),
-      register: async (payload: DesktopNotifBody): Promise<number> =>
+      register: async (payload: DesktopNotifBody): Promise<DesktopNotifPartial> =>
         this.req(
           "POST",
           `/api/v1/notifications/desktop/device`,

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -13,7 +13,8 @@ import {
   UpdateQuestionParams,
   UpdateQuestionResponse,
   UpdateQueueParams,
-  Question,, DesktopNotifPartial
+  Question,
+  DesktopNotifPartial,
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -103,7 +104,9 @@ class APIClient {
     desktop: {
       credentials: async (): Promise<string> =>
         this.req("GET", "/api/v1/notifications/desktop/credentials"),
-      register: async (payload: DesktopNotifBody): Promise<DesktopNotifPartial> =>
+      register: async (
+        payload: DesktopNotifBody
+      ): Promise<DesktopNotifPartial> =>
         this.req(
           "POST",
           `/api/v1/notifications/desktop/device`,
@@ -114,7 +117,7 @@ class APIClient {
         this.req(
           "POST",
           `/api/v1/notifications/desktop/device/${deviceId}`,
-          undefined,
+          undefined
         ),
     },
   };

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -7,7 +7,6 @@ import {
   GetQuestionResponse,
   GetQueueResponse,
   ListQuestionsResponse,
-  PhoneNotifBody,
   TAUpdateStatusResponse,
   UpdateProfileParams,
   UpdateQuestionParams,
@@ -51,7 +50,7 @@ class APIClient {
 
   profile = {
     index: async (): Promise<GetProfileResponse> =>
-      this.req("GET", `/api/v1/profile`),
+      this.req("GET", `/api/v1/profile`, GetProfileResponse),
     patch: async (body: UpdateProfileParams): Promise<GetProfileResponse> =>
       this.req("PATCH", `/api/v1/profile`, undefined, body),
   };
@@ -110,12 +109,12 @@ class APIClient {
         this.req(
           "POST",
           `/api/v1/notifications/desktop/device`,
-          undefined,
+          DesktopNotifPartial,
           payload
         ),
       unregister: async (deviceId: number): Promise<string> =>
         this.req(
-          "POST",
+          "DELETE",
           `/api/v1/notifications/desktop/device/${deviceId}`,
           undefined
         ),

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -103,12 +103,18 @@ class APIClient {
     desktop: {
       credentials: async (): Promise<string> =>
         this.req("GET", "/api/v1/notifications/desktop/credentials"),
-      register: async (payload: DesktopNotifBody): Promise<string> =>
+      register: async (payload: DesktopNotifBody): Promise<number> =>
         this.req(
           "POST",
-          `/api/v1/notifications/desktop/register`,
+          `/api/v1/notifications/desktop/device`,
           undefined,
           payload
+        ),
+      unregister: async (deviceId: number): Promise<string> =>
+        this.req(
+          "POST",
+          `/api/v1/notifications/desktop/device/${deviceId}`,
+          undefined,
         ),
     },
   };

--- a/packages/app/components/Nav/NotificationSettingsModal.tsx
+++ b/packages/app/components/Nav/NotificationSettingsModal.tsx
@@ -52,6 +52,7 @@ export function NotificationSettingsModal({
         const value = await form.validateFields();
         try {
           await editProfile(value);
+          form.setFieldsValue(profile);
           onClose();
         } catch (e) {
           if (

--- a/packages/app/components/Nav/NotificationSettingsModal.tsx
+++ b/packages/app/components/Nav/NotificationSettingsModal.tsx
@@ -130,6 +130,17 @@ function useThisDeviceEndpoint(): null | string {
   return endpoint;
 }
 
+function renderDeviceInfo(
+  device: DesktopNotifPartial,
+  isThisDevice: boolean
+): string {
+  if (device.name) {
+    return isThisDevice ? `${device.name} (This Device)` : device.name;
+  } else {
+    return isThisDevice ? "This Device" : "Other Device";
+  }
+}
+
 function DeviceNotifPanel() {
   const thisEndpoint = useThisDeviceEndpoint();
   const { data: profile, mutate } = useSWR(`api/v1/profile`, async () =>
@@ -174,26 +185,22 @@ function DeviceNotifPanel() {
         bordered
         dataSource={profile.desktopNotifs}
         locale={{ emptyText: "No Devices Registered To Receive Notifications" }}
-        renderItem={(item: DesktopNotifPartial) => (
+        renderItem={(device: DesktopNotifPartial) => (
           <List.Item
             actions={[
               <MinusCircleOutlined
                 style={{ fontSize: "20px" }}
                 key={0}
                 onClick={async () => {
-                  await API.notif.desktop.unregister(item.id);
+                  await API.notif.desktop.unregister(device.id);
                   mutate();
                 }}
               />,
             ]}
           >
             <List.Item.Meta
-              title={
-                item.endpoint === thisEndpoint
-                  ? "This Device"
-                  : "Unknown Device"
-              }
-              description={`Registered ${item.createdAt.toLocaleDateString()}`}
+              title={renderDeviceInfo(device, device.endpoint === thisEndpoint)}
+              description={`Registered ${device.createdAt.toLocaleDateString()}`}
             />
           </List.Item>
         )}

--- a/packages/app/components/Nav/NotificationSettingsModal.tsx
+++ b/packages/app/components/Nav/NotificationSettingsModal.tsx
@@ -1,14 +1,32 @@
-import { Form, Input, Modal, Row, Switch } from "antd";
+import {
+  Button,
+  Form,
+  Input,
+  List,
+  message,
+  Modal,
+  Switch,
+  Tooltip,
+} from "antd";
 import useSWR from "swr";
 import { API } from "@koh/api-client";
-import { UpdateProfileParams } from "@koh/common";
+import { DesktopNotifPartial, UpdateProfileParams } from "@koh/common";
 import { pick } from "lodash";
-import { ReactElement } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import {
   requestNotificationPermission,
   registerNotificationSubscription,
   NotificationStates,
+  getEndpoint,
+  getNotificationState,
 } from "../../utils/notification";
+import { MinusCircleOutlined } from "@ant-design/icons";
+import styled from "styled-components";
+
+const DeviceAddHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
 
 interface NotificationSettingsModalProps {
   visible: boolean;
@@ -34,12 +52,6 @@ export function NotificationSettingsModal({
         "phoneNumber",
       ])
     );
-    if (!profile.desktopNotifsEnabled && updateProfile.desktopNotifsEnabled) {
-      const canNotify = await requestNotificationPermission();
-      if (canNotify === NotificationStates.granted) {
-        await registerNotificationSubscription();
-      }
-    }
     mutate();
   };
 
@@ -68,34 +80,17 @@ export function NotificationSettingsModal({
     >
       {profile && (
         <Form form={form} initialValues={profile}>
-          <p>Get notified when you reach the top of the queue.</p>
           <Form.Item
-            label="Enable browser notifications"
+            label="Enable notifications on all devices"
             name="desktopNotifsEnabled"
             valuePropName="checked"
           >
-            <Switch
-              onChange={async (checked) => {
-                if (checked) {
-                  const canNotify = await requestNotificationPermission();
-                  if (canNotify !== NotificationStates.granted) {
-                    form.setFieldsValue({ desktopNotifsEnabled: false });
-                    form.setFields([
-                      {
-                        name: "desktopNotifsEnabled",
-                        errors: [
-                          canNotify === NotificationStates.notAllowed
-                            ? "Please allow notifications in this browser"
-                            : "Browser does not support notifications. Please use Chrome or Firefox.",
-                        ],
-                      },
-                    ]);
-                  }
-                }
-              }}
-            />
+            <Switch />
           </Form.Item>
+          <DeviceNotifPanel />
+          {/* <Divider orientation="left">SMS</Divider> */}
           <Form.Item
+            style={{ marginTop: "30px" }}
             label="Enable SMS notifications"
             name="phoneNotifsEnabled"
             valuePropName="checked"
@@ -124,5 +119,85 @@ export function NotificationSettingsModal({
         </Form>
       )}
     </Modal>
+  );
+}
+
+function useThisDeviceEndpoint(): null | string {
+  const [endpoint, setEndpoint] = useState(null);
+  useEffect(() => {
+    (async () => setEndpoint(await getEndpoint()))();
+  });
+  return endpoint;
+}
+
+function DeviceNotifPanel() {
+  const thisEndpoint = useThisDeviceEndpoint();
+  const { data: profile, mutate } = useSWR(`api/v1/profile`, async () =>
+    API.profile.index()
+  );
+  const thisDesktopNotif = profile?.desktopNotifs?.find(
+    (dn) => dn.endpoint === thisEndpoint
+  );
+  return (
+    <div>
+      <DeviceAddHeader>
+        <h3>Your Devices</h3>
+        {!thisDesktopNotif && (
+          <Tooltip
+            title={
+              getNotificationState() ===
+                NotificationStates.browserUnsupported &&
+              "Browser does not support notifications. Please use Chrome or Firefox, and not Incognito Mode."
+            }
+          >
+            <Button
+              onClick={async () => {
+                const canNotify = await requestNotificationPermission();
+                if (canNotify === NotificationStates.notAllowed) {
+                  message.warning("Please allow notifications in this browser");
+                }
+                if (canNotify === NotificationStates.granted) {
+                  await registerNotificationSubscription();
+                  mutate();
+                }
+              }}
+              disabled={
+                getNotificationState() === NotificationStates.browserUnsupported
+              }
+            >
+              Add This Device
+            </Button>
+          </Tooltip>
+        )}
+      </DeviceAddHeader>
+      <List
+        bordered
+        dataSource={profile.desktopNotifs}
+        locale={{ emptyText: "No Devices Registered To Receive Notifications" }}
+        renderItem={(item: DesktopNotifPartial) => (
+          <List.Item
+            actions={[
+              <MinusCircleOutlined
+                style={{ fontSize: "20px" }}
+                key={0}
+                onClick={async () => {
+                  await API.notif.desktop.unregister(item.id);
+                  mutate();
+                }}
+              />,
+            ]}
+          >
+            <List.Item.Meta
+              title={
+                item.endpoint === thisEndpoint
+                  ? "This Device"
+                  : "Unknown Device"
+              }
+              description={`Registered ${item.createdAt.toLocaleDateString()}`}
+            />
+          </List.Item>
+        )}
+      />
+    </div>
   );
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
     "next-compose-plugins": "^2.2.0",
     "next-offline": "^5.0.2",
     "next-transpile-modules": "^3.3.0",
+    "platform": "^1.3.6",
     "react": "16.13.1",
     "react-big-calendar": "^0.24.6",
     "react-dom": "16.13.1",

--- a/packages/app/public/service-worker.js
+++ b/packages/app/public/service-worker.js
@@ -2,12 +2,6 @@
 
 // some code taken from https://medium.com/izettle-engineering/beginners-guide-to-web-push-notifications-using-service-workers-cb3474a17679
 
-// important constants
-// todo: replace with actual user id.
-const USER_ID = 1;
-const ENDPOINT_REGISTER = `api/v1/notifications/desktop/register/${USER_ID}`;
-const ENDPOINT_CREDENTIALS = `api/v1/notifications/desktop/credentials`;
-
 self.addEventListener("push", async function (event) {
   if (event.data) {
     try {

--- a/packages/app/utils/notification.ts
+++ b/packages/app/utils/notification.ts
@@ -1,6 +1,7 @@
 import { API } from "@koh/api-client";
 import { DesktopNotifBody } from "@koh/common";
 import { urlB64ToUint8Array } from "./urlB64ToUint8Array";
+import platform from "platform";
 
 const doesBrowserSupportNotifications = () =>
   "serviceWorker" in window.navigator && "PushManager" in window;
@@ -41,7 +42,8 @@ const getRegistration = async (): Promise<ServiceWorkerRegistration> =>
 export const registerNotificationSubscription = async (): Promise<void> => {
   if (doesBrowserSupportNotifications()) {
     const subscription = await ensureSubscription();
-    await API.notif.desktop.register(subscription.toJSON() as DesktopNotifBody);
+    const subData = subscription.toJSON() as DesktopNotifBody;
+    await API.notif.desktop.register({ ...subData }); //, name: `${platform.name} on ${platform.os}`});
   }
 };
 
@@ -62,6 +64,8 @@ async function ensureSubscription(): Promise<PushSubscription> {
 }
 
 export async function getEndpoint(): Promise<string | NotificationStates> {
-  const subscription = (await (await getRegistration())?.pushManager?.getSubscription());
+  const subscription = await (
+    await getRegistration()
+  )?.pushManager?.getSubscription();
   return subscription?.endpoint;
 }

--- a/packages/app/utils/notification.ts
+++ b/packages/app/utils/notification.ts
@@ -43,7 +43,10 @@ export const registerNotificationSubscription = async (): Promise<void> => {
   if (doesBrowserSupportNotifications()) {
     const subscription = await ensureSubscription();
     const subData = subscription.toJSON() as DesktopNotifBody;
-    await API.notif.desktop.register({ ...subData }); //, name: `${platform.name} on ${platform.os}`});
+    await API.notif.desktop.register({
+      ...subData,
+      name: `${platform.name} on ${platform.os}`,
+    });
   }
 };
 

--- a/packages/app/utils/notification.ts
+++ b/packages/app/utils/notification.ts
@@ -11,24 +11,30 @@ export enum NotificationStates {
   browserUnsupported,
 }
 
+export function getNotificationState(): NotificationStates {
+  if (!doesBrowserSupportNotifications()) {
+    return NotificationStates.browserUnsupported;
+  } else if (Notification.permission === "granted") {
+    return NotificationStates.granted;
+  } else {
+    return NotificationStates.notAllowed;
+  }
+}
+
 // Tries to get notification permission and returns whether granted
 export async function requestNotificationPermission(): Promise<
   NotificationStates
 > {
-  if (!doesBrowserSupportNotifications()) {
-    return NotificationStates.browserUnsupported;
+  let state = getNotificationState();
+  if (state === NotificationStates.notAllowed) {
+    await window.Notification.requestPermission();
+    state = getNotificationState();
   }
-  if (Notification.permission === "granted") {
-    return NotificationStates.granted;
-  } else {
-    return (await window.Notification.requestPermission()) === "granted"
-      ? NotificationStates.granted
-      : NotificationStates.notAllowed;
-  }
+  return state;
 }
 
 const getRegistration = async (): Promise<ServiceWorkerRegistration> =>
-  await window.navigator.serviceWorker.getRegistration();
+  await window.navigator?.serviceWorker?.getRegistration();
 
 // 1. subscribe to pushmanager
 // 2. send subscription info to our backend
@@ -43,8 +49,8 @@ export const registerNotificationSubscription = async (): Promise<void> => {
  * Ensure we are subscribed to our browser's push service
  */
 async function ensureSubscription(): Promise<PushSubscription> {
-  const { pushManager } = await getRegistration();
-  let subscription = await pushManager.getSubscription();
+  const pushManager = (await getRegistration())?.pushManager;
+  let subscription = await pushManager?.getSubscription();
   if (subscription === null) {
     const PUBLICKEY = await API.notif.desktop.credentials();
     console.log(PUBLICKEY);
@@ -53,4 +59,9 @@ async function ensureSubscription(): Promise<PushSubscription> {
     subscription = await pushManager.subscribe(options);
   }
   return subscription;
+}
+
+export async function getEndpoint(): Promise<string | NotificationStates> {
+  const subscription = (await (await getRegistration())?.pushManager?.getSubscription());
+  return subscription?.endpoint;
 }

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -249,6 +249,7 @@ export type DesktopNotifBody = {
     p256dh: string;
     auth: string;
   };
+  name?: string;
 };
 
 export type PhoneNotifBody = {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -29,6 +29,7 @@ export const isProd = (): boolean =>
  * @param name - The full name of this user: First Last.
  * @param photoURL - The URL string of this user photo. This is pulled from the admin site
  * @param courses - The list of courses that the user is accociated with (as either a 'student', 'ta' or 'professor')
+ * @param desktopNotifs - list of endpoints so that frontend can figure out if device is enabled
  */
 export type User = {
   id: number;
@@ -37,9 +38,15 @@ export type User = {
   photoURL: string;
   courses: UserCourse[];
   desktopNotifsEnabled: boolean;
+  desktopNotifs: DesktopNotifPartial[];
   phoneNotifsEnabled: boolean;
   phoneNumber: string;
 };
+
+export interface DesktopNotifPartial {
+  id: number;
+  endpoint: string;
+}
 
 /**
  * Contains the partial user info needed by the frontend when nested in a response

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -31,21 +31,27 @@ export const isProd = (): boolean =>
  * @param courses - The list of courses that the user is accociated with (as either a 'student', 'ta' or 'professor')
  * @param desktopNotifs - list of endpoints so that frontend can figure out if device is enabled
  */
-export type User = {
-  id: number;
-  email: string;
-  name: string;
-  photoURL: string;
-  courses: UserCourse[];
-  desktopNotifsEnabled: boolean;
-  desktopNotifs: DesktopNotifPartial[];
-  phoneNotifsEnabled: boolean;
-  phoneNumber: string;
-};
+export class User {
+  id!: number;
+  email!: string;
+  name!: string;
+  photoURL!: string;
+  courses!: UserCourse[];
+  desktopNotifsEnabled!: boolean;
 
-export interface DesktopNotifPartial {
-  id: number;
-  endpoint: string;
+  @Type(() => DesktopNotifPartial)
+  desktopNotifs!: DesktopNotifPartial[];
+
+  phoneNotifsEnabled!: boolean;
+  phoneNumber!: string;
+}
+
+export class DesktopNotifPartial {
+  id!: number;
+  endpoint!: string;
+  name?: string;
+  @Type(() => Date)
+  createdAt!: Date;
 }
 
 /**
@@ -254,7 +260,7 @@ export type PhoneNotifBody = {
 // API route Params and Responses
 
 // Office Hours Response Types
-export type GetProfileResponse = User;
+export class GetProfileResponse extends User {}
 
 export class KhouryDataParams {
   @IsString()

--- a/packages/server/migration/1601671992912-DesktopNotifCreatedAtAndName.ts
+++ b/packages/server/migration/1601671992912-DesktopNotifCreatedAtAndName.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DesktopNotifCreatedAtAndName1601671992912
+  implements MigrationInterface {
+  name = 'DesktopNotifCreatedAtAndName1601671992912';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "desktop_notif_model" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "desktop_notif_model" ADD "name" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "desktop_notif_model" DROP COLUMN "name"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "desktop_notif_model" DROP COLUMN "createdAt"`,
+    );
+  }
+}

--- a/packages/server/src/notification/desktop-notif.entity.ts
+++ b/packages/server/src/notification/desktop-notif.entity.ts
@@ -5,8 +5,7 @@ import {
   BaseEntity,
   ManyToOne,
   JoinColumn,
-  AfterInsert,
-  AfterLoad,
+  CreateDateColumn,
 } from 'typeorm';
 import { UserModel } from '../profile/user.entity';
 
@@ -27,10 +26,19 @@ export class DesktopNotifModel extends BaseEntity {
   @Column('text')
   auth: string;
 
-  @ManyToOne((type) => UserModel, (user) => user.desktopNotifs)
+  @ManyToOne(
+    type => UserModel,
+    user => user.desktopNotifs,
+  )
   @JoinColumn({ name: 'userId' })
   user: UserModel;
 
   @Column({ nullable: true })
   userId: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @Column({ type: 'text', nullable: true })
+  name: string;
 }

--- a/packages/server/src/notification/desktop-notif.entity.ts
+++ b/packages/server/src/notification/desktop-notif.entity.ts
@@ -26,10 +26,7 @@ export class DesktopNotifModel extends BaseEntity {
   @Column('text')
   auth: string;
 
-  @ManyToOne(
-    type => UserModel,
-    user => user.desktopNotifs,
-  )
+  @ManyToOne((type) => UserModel, (user) => user.desktopNotifs)
   @JoinColumn({ name: 'userId' })
   user: UserModel;
 

--- a/packages/server/src/notification/notification.controller.ts
+++ b/packages/server/src/notification/notification.controller.ts
@@ -1,19 +1,23 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Header,
   Headers,
+  NotFoundException,
+  Param,
   Post,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { DesktopNotifBody, TwilioBody } from '@koh/common';
+import { DesktopNotifBody, DesktopNotifPartial, TwilioBody } from '@koh/common';
 import * as twilio from 'twilio';
 import { JwtAuthGuard } from '../login/jwt-auth.guard';
 import { NotificationService } from './notification.service';
 import { UserId } from '../profile/user.decorator';
+import { DesktopNotifModel } from './desktop-notif.entity';
 
 @Controller('notifications')
 export class NotificationController {
@@ -28,20 +32,34 @@ export class NotificationController {
     return JSON.stringify(this.notifService.desktopPublicKey);
   }
 
-  @Post('desktop/register')
+  @Post('desktop/device')
   @UseGuards(JwtAuthGuard)
   async registerDesktopUser(
     @Body() body: DesktopNotifBody,
     @UserId() userId: number,
-  ): Promise<string> {
-    await this.notifService.registerDesktop({
+  ): Promise<DesktopNotifPartial> {
+    const device = await this.notifService.registerDesktop({
       endpoint: body.endpoint,
       expirationTime: body.expirationTime && new Date(body.expirationTime),
       p256dh: body.keys.p256dh,
       auth: body.keys.auth,
       userId: userId,
     });
-    return 'registration success';
+    return { id: device.id, endpoint: device.endpoint };
+  }
+
+  @Delete('desktop/device/:deviceId')
+  @UseGuards(JwtAuthGuard)
+  async deleteDesktopUser(
+    @Param('deviceId') deviceId: number,
+    @UserId() userId: number,
+  ): Promise<void> {
+    const dn = await DesktopNotifModel.find({ id: deviceId, userId });
+    if (dn.length > 0) {
+      await DesktopNotifModel.remove(dn);
+    } else {
+      throw new NotFoundException();
+    }
   }
 
   // Webhook from twilio

--- a/packages/server/src/notification/notification.controller.ts
+++ b/packages/server/src/notification/notification.controller.ts
@@ -45,7 +45,12 @@ export class NotificationController {
       auth: body.keys.auth,
       userId: userId,
     });
-    return { id: device.id, endpoint: device.endpoint };
+    return {
+      id: device.id,
+      endpoint: device.endpoint,
+      createdAt: device.createdAt,
+      name: device.name,
+    };
   }
 
   @Delete('desktop/device/:deviceId')

--- a/packages/server/src/notification/notification.controller.ts
+++ b/packages/server/src/notification/notification.controller.ts
@@ -43,6 +43,7 @@ export class NotificationController {
       expirationTime: body.expirationTime && new Date(body.expirationTime),
       p256dh: body.keys.p256dh,
       auth: body.keys.auth,
+      name: body.name,
       userId: userId,
     });
     return {

--- a/packages/server/src/notification/notification.service.ts
+++ b/packages/server/src/notification/notification.service.ts
@@ -116,7 +116,7 @@ export class NotificationService {
     // run the promises concurrently
     if (notifModelsOfUser.desktopNotifsEnabled) {
       await Promise.all(
-        notifModelsOfUser.desktopNotifs.map(async nm =>
+        notifModelsOfUser.desktopNotifs.map(async (nm) =>
           this.notifyDesktop(nm, message),
         ),
       );

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -2,7 +2,11 @@ import { Controller, Get, UseGuards, Patch, Body } from '@nestjs/common';
 import { Connection } from 'typeorm';
 import { UserModel } from './user.entity';
 import { pick } from 'lodash';
-import { GetProfileResponse, UpdateProfileParams } from '@koh/common';
+import {
+  DesktopNotifPartial,
+  GetProfileResponse,
+  UpdateProfileParams,
+} from '@koh/common';
 import { JwtAuthGuard } from '../login/jwt-auth.guard';
 import { User } from './user.decorator';
 import { NotificationService } from '../notification/notification.service';
@@ -17,11 +21,12 @@ export class ProfileController {
 
   @Get()
   async get(
-    @User(['courses', 'courses.course', 'phoneNotif']) user: UserModel,
+    @User(['courses', 'courses.course', 'phoneNotif', 'desktopNotifs'])
+    user: UserModel,
   ): Promise<GetProfileResponse> {
     const courses = user.courses
-      .filter((userCourse) => userCourse.course.enabled)
-      .map((userCourse) => {
+      .filter(userCourse => userCourse.course.enabled)
+      .map(userCourse => {
         return {
           course: {
             id: userCourse.courseId,
@@ -30,6 +35,11 @@ export class ProfileController {
           role: userCourse.role,
         };
       });
+
+    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(d => ({
+      endpoint: d.endpoint,
+      id: d.id,
+    }));
 
     const userResponse = pick(user, [
       'id',
@@ -43,13 +53,15 @@ export class ProfileController {
       ...userResponse,
       courses,
       phoneNumber: user.phoneNotif?.phoneNumber,
+      desktopNotifs,
     };
   }
 
   @Patch()
   async patch(
     @Body() userPatch: UpdateProfileParams,
-    @User(['courses', 'courses.course', 'phoneNotif']) user: UserModel,
+    @User(['courses', 'courses.course', 'phoneNotif', 'desktopNotifs'])
+    user: UserModel,
   ): Promise<GetProfileResponse> {
     user = Object.assign(user, userPatch);
     if (
@@ -60,28 +72,6 @@ export class ProfileController {
     }
     await user.save();
 
-    const courses = user.courses.map((userCourse) => {
-      return {
-        course: {
-          id: userCourse.courseId,
-          name: userCourse.course.name,
-        },
-        role: userCourse.role,
-      };
-    });
-
-    const userResponse = pick(user, [
-      'id',
-      'email',
-      'name',
-      'photoURL',
-      'desktopNotifsEnabled',
-      'phoneNotifsEnabled',
-    ]);
-    return {
-      ...userResponse,
-      courses,
-      phoneNumber: user.phoneNotif?.phoneNumber,
-    };
+    return this.get(user);
   }
 }

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -25,8 +25,8 @@ export class ProfileController {
     user: UserModel,
   ): Promise<GetProfileResponse> {
     const courses = user.courses
-      .filter(userCourse => userCourse.course.enabled)
-      .map(userCourse => {
+      .filter((userCourse) => userCourse.course.enabled)
+      .map((userCourse) => {
         return {
           course: {
             id: userCourse.courseId,
@@ -36,12 +36,14 @@ export class ProfileController {
         };
       });
 
-    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(d => ({
-      endpoint: d.endpoint,
-      id: d.id,
-      createdAt: d.createdAt,
-      name: d.name,
-    }));
+    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(
+      (d) => ({
+        endpoint: d.endpoint,
+        id: d.id,
+        createdAt: d.createdAt,
+        name: d.name,
+      }),
+    );
 
     const userResponse = pick(user, [
       'id',

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -25,8 +25,8 @@ export class ProfileController {
     user: UserModel,
   ): Promise<GetProfileResponse> {
     const courses = user.courses
-      .filter(userCourse => userCourse.course.enabled)
-      .map(userCourse => {
+      .filter((userCourse) => userCourse.course.enabled)
+      .map((userCourse) => {
         return {
           course: {
             id: userCourse.courseId,
@@ -36,10 +36,12 @@ export class ProfileController {
         };
       });
 
-    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(d => ({
-      endpoint: d.endpoint,
-      id: d.id,
-    }));
+    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(
+      (d) => ({
+        endpoint: d.endpoint,
+        id: d.id,
+      }),
+    );
 
     const userResponse = pick(user, [
       'id',

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -25,8 +25,8 @@ export class ProfileController {
     user: UserModel,
   ): Promise<GetProfileResponse> {
     const courses = user.courses
-      .filter((userCourse) => userCourse.course.enabled)
-      .map((userCourse) => {
+      .filter(userCourse => userCourse.course.enabled)
+      .map(userCourse => {
         return {
           course: {
             id: userCourse.courseId,
@@ -36,12 +36,12 @@ export class ProfileController {
         };
       });
 
-    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(
-      (d) => ({
-        endpoint: d.endpoint,
-        id: d.id,
-      }),
-    );
+    const desktopNotifs: DesktopNotifPartial[] = user.desktopNotifs.map(d => ({
+      endpoint: d.endpoint,
+      id: d.id,
+      createdAt: d.createdAt,
+      name: d.name,
+    }));
 
     const userResponse = pick(user, [
       'id',

--- a/packages/server/test/__snapshots__/profile.integration.ts.snap
+++ b/packages/server/test/__snapshots__/profile.integration.ts.snap
@@ -11,6 +11,7 @@ Object {
       "role": "student",
     },
   ],
+  "desktopNotifs": Array [],
   "desktopNotifsEnabled": false,
   "email": "user@neu.edu",
   "id": 1,

--- a/packages/server/test/notif.integration.ts
+++ b/packages/server/test/notif.integration.ts
@@ -58,13 +58,13 @@ describe('Notif Integration', () => {
         endpoint: 'abc',
       }).save();
       await dn.reload();
-      expect(await DesktopNotifModel.count()).toEqual(1)
+      expect(await DesktopNotifModel.count()).toEqual(1);
 
       await supertest({ userId: user.id })
         .delete(`/notifications/desktop/device/${dn.id}`)
         .expect(200);
 
-      expect(await DesktopNotifModel.count()).toEqual(0)
+      expect(await DesktopNotifModel.count()).toEqual(0);
     });
 
     it('does not let users remove other users desktopnotifs', async () => {
@@ -77,14 +77,14 @@ describe('Notif Integration', () => {
         endpoint: 'abc',
       }).save();
       await dn.reload();
-      expect(await DesktopNotifModel.count()).toEqual(1)
+      expect(await DesktopNotifModel.count()).toEqual(1);
 
       const hackerman = await UserFactory.create();
       await supertest({ userId: hackerman.id })
         .delete(`/notifications/desktop/device/${dn.id}`)
         .expect(404);
 
-      expect(await DesktopNotifModel.count()).toEqual(1)
+      expect(await DesktopNotifModel.count()).toEqual(1);
     });
   });
 });

--- a/packages/server/test/notif.integration.ts
+++ b/packages/server/test/notif.integration.ts
@@ -29,9 +29,15 @@ describe('Notif Integration', () => {
             p256dh: 'some_key',
             auth: 'some_key_as_well',
           },
+          name: 'chrome',
         })
         .expect(201);
-      expect(res.body).toEqual({ endpoint: 'biggoogle.com', id: 1 });
+      expect(res.body).toEqual({
+        createdAt: expect.any(String),
+        name: 'chrome',
+        endpoint: 'biggoogle.com',
+        id: 1,
+      });
 
       const notifModels = await DesktopNotifModel.find();
       expect(notifModels).toEqual([
@@ -42,6 +48,8 @@ describe('Notif Integration', () => {
           id: 1,
           p256dh: 'some_key',
           userId: 1,
+          createdAt: expect.any(Date),
+          name: 'chrome',
         },
       ]);
     });

--- a/packages/server/test/profile.integration.ts
+++ b/packages/server/test/profile.integration.ts
@@ -55,13 +55,19 @@ describe('Profile Integration', () => {
         auth: '',
         p256dh: '',
         endpoint: 'abc',
+        name: 'firefox',
       }).save();
       await dn.reload();
       const res = await supertest({ userId: user.id })
         .get('/profile')
         .expect(200);
       expect(res.body.desktopNotifs).toEqual([
-        { id: dn.id, endpoint: dn.endpoint },
+        {
+          createdAt: expect.any(String),
+          name: 'firefox',
+          id: dn.id,
+          endpoint: dn.endpoint,
+        },
       ]);
     });
 

--- a/packages/server/test/profile.integration.ts
+++ b/packages/server/test/profile.integration.ts
@@ -6,6 +6,7 @@ import {
 import { setupIntegrationTest } from './util/testUtils';
 import { ProfileModule } from '../src/profile/profile.module';
 import { PhoneNotifModel } from 'notification/phone-notif.entity';
+import { DesktopNotifModel } from 'notification/desktop-notif.entity';
 
 describe('Profile Integration', () => {
   const supertest = setupIntegrationTest(ProfileModule);
@@ -47,6 +48,23 @@ describe('Profile Integration', () => {
       ]);
     });
 
+    it('returns desktop notif information', async () => {
+      const user = await UserFactory.create();
+      const dn = await DesktopNotifModel.create({
+        user,
+        auth: '',
+        p256dh:'',
+        endpoint: 'abc',
+      }).save();
+      await dn.reload();
+      const res = await supertest({ userId: user.id })
+        .get('/profile')
+        .expect(200);
+      expect(res.body.desktopNotifs).toEqual([
+        { id: dn.id, endpoint: dn.endpoint },
+      ]);
+    });
+
     it('returns 401 when not logged in', async () => {
       await UserFactory.create();
       await supertest()
@@ -82,7 +100,7 @@ describe('Profile Integration', () => {
       expect(res.body).toMatchObject({
         desktopNotifsEnabled: false,
         phoneNotifsEnabled: true,
-        phoneNumber: 'real911'
+        phoneNumber: 'real911',
       });
     });
     it('does not let student enable without phone number', async () => {

--- a/packages/server/test/profile.integration.ts
+++ b/packages/server/test/profile.integration.ts
@@ -53,7 +53,7 @@ describe('Profile Integration', () => {
       const dn = await DesktopNotifModel.create({
         user,
         auth: '',
-        p256dh:'',
+        p256dh: '',
         endpoint: 'abc',
       }).save();
       await dn.reload();
@@ -67,9 +67,7 @@ describe('Profile Integration', () => {
 
     it('returns 401 when not logged in', async () => {
       await UserFactory.create();
-      await supertest()
-        .get('/profile')
-        .expect(401);
+      await supertest().get('/profile').expect(401);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,6 +10201,11 @@ platform@1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
   integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
+platform@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"


### PR DESCRIPTION
## Regular Usage
![devices](https://user-images.githubusercontent.com/7122182/94968657-5114ef80-04cf-11eb-9016-fc7b3c9f0b4c.gif)

## When User Does Not Allow Notif
![device not allowed](https://user-images.githubusercontent.com/7122182/94968761-815c8e00-04cf-11eb-89ed-f6f980259706.gif)

## In Incognito
![image](https://user-images.githubusercontent.com/7122182/94968831-9cc79900-04cf-11eb-9385-4fece8d64f7c.png)

# Implementation

- Added code to send browser/OS info when registering for desktop notif.
- Added endpoint to delete your desktopnotif
- Return list of desktopnotifs in profile endpoint (redacted the sensistive info)
- Frontend just renders a list accordingly
