### PR TITLE
fix default course sync

### DIFF
--- a/packages/app/hooks/useDefaultCourseRedirect.ts
+++ b/packages/app/hooks/useDefaultCourseRedirect.ts
@@ -7,10 +7,14 @@ export function useDefaultCourseRedirect(): boolean {
   const profile: User = useProfile();
   const [defaultCourse] = useLocalStorage("defaultCourse", null);
   if (profile && profile.courses.length > 0) {
+    /// defaultCourse can get out-of-sync with the user's actual registered course (dropped class etc)
+    const isUserInDefaultCourse =
+      !!defaultCourse &&
+      profile.courses.some((c) => c.course.id === defaultCourse?.id);
     Router.push(
       "/course/[cid]/today",
       `/course/${
-        defaultCourse !== null ? defaultCourse.id : profile.courses[0].course.id
+        isUserInDefaultCourse ? defaultCourse.id : profile.courses[0].course.id
       }/today`
     );
     return true;


### PR DESCRIPTION
Sometimes, if a student drops a class or logs in as a different user, they will end up getting redirected to a defaultCourse that they are not a member of and encounter a weird blank screen with just the footer and navbar. This fixes that, although we probably also want to make a 404 page for when people try to view class they aren't a member of.