### PR TITLE
Question modal reset bug

### DIFF
--- a/packages/app/components/Queue/Student/QuestionForm.tsx
+++ b/packages/app/components/Queue/Student/QuestionForm.tsx
@@ -65,11 +65,11 @@ export default function QuestionForm({
   );
 
   useEffect(() => {
-    if (question) {
+    if (question && !visible) {
       setQuestionText(question.text);
       setQuestionTypeInput(question.questionType);
     }
-  }, [question]);
+  }, [question, visible]);
 
   // on question type change, update the question type state
   const onCategoryChange = (e: RadioChangeEvent) => {


### PR DESCRIPTION
The bug occurs when updates from the api will reset the data in the question modal. This is an issue both when editing and updating a question. 

![question_drafing_bug](https://user-images.githubusercontent.com/33739155/97037185-edfb0380-1536-11eb-81f1-006b4666ddbd.gif)
