### PR TITLE
Change notify request method to match the backend

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -86,7 +86,7 @@ class APIClient {
         params
       ),
     notify: async (questionId: number): Promise<void> =>
-      this.req("PATCH", `/api/v1/questions/${questionId}/notify`),
+      this.req("POST", `/api/v1/questions/${questionId}/notify`),
   };
   queues = {
     get: async (queueId: number): Promise<GetQueueResponse> =>


### PR DESCRIPTION
The notify endpoint is looking for a `POST` request but we were sending it a `PATCH`
https://github.com/sandboxnu/office-hours/blob/95c110a82ec2b6e14dc6e7ee0d587d0b98b5c961/packages/server/src/question/question.controller.ts#L220