### PR TITLE
Priority Queue style fixes

### DIFF
--- a/packages/app/components/Queue/QueueCardSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueCardSharedComponents.tsx
@@ -58,7 +58,20 @@ export function questionStatusToColor(status: QuestionStatus): string {
       return "red";
     case QuestionStatusKeys.Drafting:
       return "blue";
+    case QuestionStatusKeys.PriorityQueued:
+      return "green";
     default:
       return "purple";
+  }
+}
+
+export function questionStatusToText(status: QuestionStatus): string {
+  switch (status) {
+    case QuestionStatusKeys.CantFind:
+      return "Can't Find";
+    case QuestionStatusKeys.PriorityQueued:
+      return "Priority";
+    default:
+      return status;
   }
 }

--- a/packages/app/components/Queue/Student/StudentBanner.tsx
+++ b/packages/app/components/Queue/Student/StudentBanner.tsx
@@ -35,6 +35,12 @@ const ColWithRightMargin = styled(Col)`
   margin-right: 32px;
 `;
 
+const PriorityQueuedBanner = styled.span`
+  display: flex;
+  flex-direction: column;
+  margin: 12px 0;
+`;
+
 interface StudentBannerProps {
   queueId: number;
   editQuestion: () => void;
@@ -198,10 +204,16 @@ export default function StudentBanner({
           titleColor="#3684C6"
           contentColor="#ABD4F3"
           title={
-            <span>
+            <PriorityQueuedBanner>
               You are now in a priority queue, you will be helped soon. <br />
-              You were last helped by {studentQuestion.taHelped.name}.
-            </span>
+              <span style={{ fontSize: 16 }}>
+                You were last helped by{" "}
+                <span style={{ fontWeight: "bold" }}>
+                  {studentQuestion.taHelped.name}
+                </span>
+                .
+              </span>
+            </PriorityQueuedBanner>
           }
           buttons={
             <>

--- a/packages/app/components/Queue/TA/TAQueueCard.tsx
+++ b/packages/app/components/Queue/TA/TAQueueCard.tsx
@@ -9,6 +9,7 @@ import {
   CenterRow,
   HorizontalTACard,
   questionStatusToColor,
+  questionStatusToText,
   Rank,
   StatusTag,
   Text,
@@ -69,9 +70,7 @@ export default function TAQueueCard({
         </Col>
         <Col span={2}>
           <StatusTag color={questionStatusToColor(question.status)}>
-            {question.status === LimboQuestionStatus.CantFind
-              ? "Can't Find"
-              : question.status}
+            {questionStatusToText(question.status)}
           </StatusTag>
         </Col>
         <Col>

--- a/packages/app/utils/notification.ts
+++ b/packages/app/utils/notification.ts
@@ -23,9 +23,7 @@ export function getNotificationState(): NotificationStates {
 }
 
 // Tries to get notification permission and returns whether granted
-export async function requestNotificationPermission(): Promise<
-  NotificationStates
-> {
+export async function requestNotificationPermission(): Promise<NotificationStates> {
   let state = getNotificationState();
   if (state === NotificationStates.notAllowed) {
     await window.Notification.requestPermission();


### PR DESCRIPTION
Changes styling for requeued banner and Priority question status.

<img width="807" alt="Screen Shot 2020-11-21 at 9 17 37 PM" src="https://user-images.githubusercontent.com/17220434/99892102-655baa00-2c3f-11eb-822c-c6166ae015b1.png">

<img width="810" alt="Screen Shot 2020-11-21 at 9 17 49 PM" src="https://user-images.githubusercontent.com/17220434/99892113-7dcbc480-2c3f-11eb-8564-71c23d9ba024.png">