### PR TITLE
Add retries to cypress to find flakey tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,9 @@
   "projectId": "8crkwu",
   "baseUrl": "http://localhost:3000",
   "defaultCommandTimeout": 10000,
+  "retries": {
+    "runMode": 2
+  },
   "env": {
     "USE_LIVE_API": false,
     "UPDATE_FIXTURES": false


### PR DESCRIPTION
Flakey tests are no fun. 😞 

Fortunately, cypress can help us figure out which tests are flakey so we can eliminate them. 
![image](https://user-images.githubusercontent.com/33739155/100476235-e8468f80-3099-11eb-9c68-670e295da94a.png)
