### PR TITLE
Maybe Fix Cypress Flake

### DIFF
--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -33,6 +33,8 @@ const makeRequest = (request, identifier, { ...params }) => {
 export const loginUser = (identifier) => {
   cy.get(`@${identifier}`).then((userCourse) => {
     cy.visit(`/api/v1/login/dev?userId=${userCourse.user.id}`);
+    // wait for the defaultCourseRedirect
+    cy.url().should("include", "today");
   });
 };
 


### PR DESCRIPTION
Noticed many cypress flakes were a result of the defaultCourseRedirect sending the browser to /today **after** cypress called .visit on the queue page, so we'd end up stuck on the today page, when the test expected us to be on the queue page. This waits for that redirect before proceeding. Thank the lord for the utils file, this is a tiny change.
