### PR TITLE
Give docker project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typeorm": "yarn workspace @koh/server typeorm",
     "dev": "concurrently -n \"server,app,proxy\" \"yarn workspace @koh/server dev\" \"yarn workspace @koh/app dev\" \"yarn dev:proxy\"",
     "dev:proxy": "node infrastructure/dev/devProxy.js",
-    "dev:db:up": "docker-compose -f infrastructure/dev/docker-compose.yml up -d",
+    "dev:db:up": "docker-compose -p officehours -f infrastructure/dev/docker-compose.yml up -d",
     "dev:db:down": "docker-compose -f infrastructure/dev/docker-compose.yml down",
     "dev:db:reset": "yarn workspace @koh/server run dev:db:reset",
     "migration:generate": "yarn workspace @koh/server run migration:generate",


### PR DESCRIPTION
Give docker compose a project name. this prevents clashing with other projects. namely, i can't develop on search and office hours at the same time because the docker compose resources start clashing﻿
