### PR TITLE
Zero Downtime

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,6 +21,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
       - run: echo "::set-output name=version::$(git rev-parse origin/master)"
         id: pre-version
       - uses: bahmutov/npm-install@v1
-      - name: Delete old builds
-        run: rm -rf packages/app/.next
       - run: yarn build
         env:
           NEXT_PUBLIC_APM_SERVER: ${{ secrets.ELASTIC_APM_SERVER_URL}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v1
       - name: install node v12

--- a/infrastructure/dev/docker-compose.yml
+++ b/infrastructure/dev/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=dev,test
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
 
 volumes:
   pg:

--- a/infrastructure/dev/docker-compose.yml
+++ b/infrastructure/dev/docker-compose.yml
@@ -12,10 +12,6 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=dev,test
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=
-  redis:
-    image: redis:alpine
-    ports:
-      - "6379:6379"
 
 volumes:
   pg:

--- a/infrastructure/prod/ecosystem.config.js
+++ b/infrastructure/prod/ecosystem.config.js
@@ -2,9 +2,11 @@ module.exports = {
   apps: [
     {
       name: "app",
-      script: "npm",
-      args: "run prod:start",
+      script: "./node_modules/.bin/next",
+      args: "start -p 3001",
       cwd: "./packages/app",
+      instances: 2,
+      exec_mode: "cluster",
       env: {
         NODE_ENV: "production",
       },
@@ -13,7 +15,7 @@ module.exports = {
       name: "server",
       cwd: "./packages/server",
       script: "dist/main.js",
-      node_args: "--max-old-space-size=8192",
+      node_args: "--max-old-space-size=4096",
       instances: 2,
       exec_mode: "cluster",
       env: {

--- a/infrastructure/prod/ecosystem.config.js
+++ b/infrastructure/prod/ecosystem.config.js
@@ -11,9 +11,11 @@ module.exports = {
     },
     {
       name: "server",
-      script: "npm",
-      args: "run prod:start",
       cwd: "./packages/server",
+      script: "dist/main.js",
+      node_args: "--max-old-space-size=8192",
+      instances: 2,
+      exec_mode: "cluster",
       env: {
         NODE_ENV: "production",
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:db:reset": "yarn workspace @koh/server run dev:db:reset",
     "migration:generate": "yarn workspace @koh/server run migration:generate",
     "build": "yarn workspace @koh/server run build && yarn workspace @koh/app run build",
-    "prod:start": "pm2 startOrRestart ./infrastructure/prod/ecosystem.config.js --time",
+    "prod:start": "pm2 startOrReload ./infrastructure/prod/ecosystem.config.js --time",
     "prod:stop": "pm2 del ./infrastructure/prod/ecosystem.config.js",
     "deploy": "pm2 deploy infrastructure/prod/ecosystem.config.js",
     "ci:start": "yarn concurrently \"yarn dev:proxy\" \"yarn workspace @koh/server prod:start\" \"yarn workspace @koh/app prod:start\""

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -68,7 +68,6 @@ export default function Today(): ReactElement {
     mutateCourse();
   };
 
-  console.log(course, profile);
   const queueCheckedIn = course?.queues.find((queue) =>
     queue.staffList.find((staff) => staff.id === profile?.id)
   );

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -68,8 +68,9 @@ export default function Today(): ReactElement {
     mutateCourse();
   };
 
+  console.log(course, profile);
   const queueCheckedIn = course?.queues.find((queue) =>
-    queue.staffList.find((staff) => staff.id === profile.id)
+    queue.staffList.find((staff) => staff.id === profile?.id)
   );
 
   return (

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,6 +45,7 @@
     "morgan": "^1.10.0",
     "nestjs-admin": "^0.4.0",
     "nestjs-command": "^1.5.0",
+    "nestjs-redis": "^1.2.8",
     "node-ical": "^0.11.3",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -15,6 +15,7 @@ import { SSEModule } from './sse/sse.module';
 import * as typeormConfig from '../ormconfig';
 import { BackfillModule } from 'backfill/backfill.module';
 import { ReleaseNotesModule } from 'release-notes/release-notes.module';
+import { RedisModule } from 'nestjs-redis';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { ReleaseNotesModule } from 'release-notes/release-notes.module';
     SSEModule,
     BackfillModule,
     ReleaseNotesModule,
+    RedisModule.register([{ name: 'pub' }, { name: 'sub' }, {name: 'db'}]),
   ],
 })
 export class AppModule {}

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -40,6 +40,7 @@ import { RedisModule } from 'nestjs-redis';
     SSEModule,
     BackfillModule,
     ReleaseNotesModule,
+    // Only use 'pub' for publishing events, 'sub' for subscribing, and 'db' for writing to key/value store
     RedisModule.register([{ name: 'pub' }, { name: 'sub' }, { name: 'db' }]),
   ],
 })

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -12,6 +12,7 @@ export async function bootstrap(hot: any): Promise<void> {
   const app = await NestFactory.create(AppModule, {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });
+  app.enableShutdownHooks(); // So we can clean up SSE.
   addGlobalsToApp(app);
   app.setGlobalPrefix('api/v1');
   app.useGlobalInterceptors(new ApmInterceptor());

--- a/packages/server/src/queue/queue-sse.service.ts
+++ b/packages/server/src/queue/queue-sse.service.ts
@@ -23,11 +23,11 @@ export class QueueSSEService {
     res: Response,
     metadata: QueueClientMetadata,
   ): void {
-    this.sseService.subscribeClient(idToRoom(queueId), { res, metadata });
+    this.sseService.subscribeClient(idToRoom(queueId), res, metadata);
   }
 
   // Send event with new questions, but no more than once a second
-  updateQuestions = this.throttleUpdate(async (queueId) => {
+  updateQuestions = this.throttleUpdate(async queueId => {
     const questions = await this.queueService.getQuestions(queueId);
     if (questions) {
       this.sendToRoom(queueId, async ({ role, userId }) => ({
@@ -41,7 +41,7 @@ export class QueueSSEService {
     }
   });
 
-  updateQueue = this.throttleUpdate(async (queueId) => {
+  updateQueue = this.throttleUpdate(async queueId => {
     const queue = await this.queueService.getQueue(queueId);
     if (queue) {
       await this.sendToRoom(queueId, async () => ({ queue }));

--- a/packages/server/src/queue/queue-sse.service.ts
+++ b/packages/server/src/queue/queue-sse.service.ts
@@ -27,7 +27,7 @@ export class QueueSSEService {
   }
 
   // Send event with new questions, but no more than once a second
-  updateQuestions = this.throttleUpdate(async queueId => {
+  updateQuestions = this.throttleUpdate(async (queueId) => {
     const questions = await this.queueService.getQuestions(queueId);
     if (questions) {
       this.sendToRoom(queueId, async ({ role, userId }) => ({
@@ -41,7 +41,7 @@ export class QueueSSEService {
     }
   });
 
-  updateQueue = this.throttleUpdate(async queueId => {
+  updateQueue = this.throttleUpdate(async (queueId) => {
     const queue = await this.queueService.getQueue(queueId);
     if (queue) {
       await this.sendToRoom(queueId, async () => ({ queue }));

--- a/packages/server/src/sse/sse.service.ts
+++ b/packages/server/src/sse/sse.service.ts
@@ -61,7 +61,11 @@ export class SSEService<T> implements OnModuleDestroy {
   }
 
   /** Add a client to a room */
-  async subscribeClient(room: string, res: Response, metadata: T): Promise<void> {
+  async subscribeClient(
+    room: string,
+    res: Response,
+    metadata: T,
+  ): Promise<void> {
     const redisSub = this.redisService.getClient('sub');
     const redis = this.redisService.getClient('db');
     // Keep track of responses so we can send sse through them

--- a/packages/server/src/sse/sse.service.ts
+++ b/packages/server/src/sse/sse.service.ts
@@ -50,7 +50,7 @@ export class SSEService<T> implements OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     // Cleanup all direct connections by removing them from the rooms in redis.
-    await each(Object.values(this.directConnnections), async conn => {
+    await each(Object.values(this.directConnnections), async (conn) => {
       await conn.cleanup();
     });
   }
@@ -104,7 +104,7 @@ export class SSEService<T> implements OnModuleDestroy {
     const redis = this.redisService.getClient('db');
     const roomInfo = await redis.smembers(room);
     if (room) {
-      const clients: RedisClientInfo<T>[] = roomInfo.map(s => JSON.parse(s));
+      const clients: RedisClientInfo<T>[] = roomInfo.map((s) => JSON.parse(s));
       console.log(`sending sse to ${clients.length} clients in ${room}`);
       console.time(`sending sse time: `);
       apm.startTransaction('sse');

--- a/packages/server/src/sse/sse.service.ts
+++ b/packages/server/src/sse/sse.service.ts
@@ -2,33 +2,76 @@ import { Injectable } from '@nestjs/common';
 import { serialize } from 'class-transformer';
 import * as apm from 'elastic-apm-node';
 import { Response } from 'express';
+import { RedisService } from 'nestjs-redis';
 
 export interface Client<T> {
   metadata: T;
   res: Response;
+}
+
+interface RedisClientInfo<T> {
+  clientId: number;
+  metadata: T;
 }
 /**
  * T is metadata associated with each Client
  *
  * Low level abstraction for sending SSE to "rooms" of clients.
  * Probably don't use this directly, and wrap it in a service specific to that event source
+ *
+ * This handles when there's multiple backend instances by assigning unique client ids.
+ * When one instance wants to send to a client, it publishes to a Redis channel for the client.
+ * All instances listen to Redis, and if they are the one managing that client, they send the msg.
+ *
+ * Rooms with client metadata are also maintained in Redis key/value store.
  */
 @Injectable()
 export class SSEService<T> {
-  private clients: Record<any, Client<T>[]> = {};
+  // Clients connected to this instance of the backend
+  private clientsConnectedDirectly: Record<number, Response> = {};
+
+  constructor(private readonly redisService: RedisService) {
+    const redisSub = this.redisService.getClient('sub');
+
+    // If channel is managed by this instance, send the message to the Response object.
+    redisSub.on('message', (channel, message) => {
+      console.log('MESSAGE');
+      const id = /sse::client-(\d+)/.exec(channel);
+      console.log(id, Object.keys(this.clientsConnectedDirectly));
+      if (id && id[1] in this.clientsConnectedDirectly) {
+        this.clientsConnectedDirectly[id[1]].write(`data: ${message}\n\n`);
+      }
+    });
+  }
+
+  /**
+   * Get redis channel name from client id
+   */
+  private idToChannel(clientId: number) {
+    return `sse::client-${clientId}`;
+  }
 
   /** Add a client to a room */
-  subscribeClient(room: string, client: Client<T>): void {
+  async subscribeClient(room: string, client: Client<T>): Promise<void> {
+    const redisSub = this.redisService.getClient('sub');
+    const redis = this.redisService.getClient('db');
     // Keep track of responses so we can send sse through them
-    if (!(room in this.clients)) {
-      this.clients[room] = [];
-    }
-    const roomref = this.clients[room];
-    roomref.push(client);
+    const clientId = await redis.incr('client::id');
+    this.clientsConnectedDirectly[clientId] = client.res;
+    // Subscribe to the redis channel for this client
+    await redisSub.subscribe(this.idToChannel(clientId));
+
+    // Add to room
+    const clientInfo = JSON.stringify({
+      clientId,
+      metadata: client.metadata,
+    } as RedisClientInfo<T>);
+    await redis.sadd(room, clientInfo);
 
     // Remove dead connections!
-    client.res.socket.on('end', () => {
-      roomref.splice(roomref.indexOf(client), 1);
+    client.res.socket.on('end', async () => {
+      delete this.clientsConnectedDirectly[clientId];
+      await redis.srem(room, clientInfo);
     });
   }
 
@@ -37,15 +80,17 @@ export class SSEService<T> {
     room: string,
     payload: (metadata: T) => Promise<D>,
   ): Promise<void> {
-    if (room in this.clients) {
-      console.log(
-        `sending sse to ${this.clients[room].length} clients in ${room}`,
-      );
+    const redisPub = this.redisService.getClient('pub');
+    const redis = this.redisService.getClient('db');
+    const roomInfo = await redis.smembers(room);
+    if (room) {
+      const clients: RedisClientInfo<T>[] = roomInfo.map(s => JSON.parse(s));
+      console.log(`sending sse to ${clients.length} clients in ${room}`);
       console.time(`sending sse time: `);
       apm.startTransaction('sse');
-      for (const { res, metadata } of this.clients[room]) {
-        const toSend = `data: ${serialize(await payload(metadata))}\n\n`;
-        res.write(toSend);
+      for (const { clientId, metadata } of clients) {
+        const toSend = serialize(await payload(metadata));
+        await redisPub.publish(this.idToChannel(clientId), toSend);
       }
       apm.endTransaction();
       console.timeEnd(`sending sse time: `);

--- a/packages/server/src/sse/sse.service.ts
+++ b/packages/server/src/sse/sse.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { each } from 'async';
 import { serialize } from 'class-transformer';
 import * as apm from 'elastic-apm-node';
 import { Response } from 'express';
@@ -7,6 +8,11 @@ import { RedisService } from 'nestjs-redis';
 export interface Client<T> {
   metadata: T;
   res: Response;
+}
+
+interface Connection {
+  res: Response;
+  cleanup: () => Promise<void>;
 }
 
 interface RedisClientInfo<T> {
@@ -19,28 +25,33 @@ interface RedisClientInfo<T> {
  * Low level abstraction for sending SSE to "rooms" of clients.
  * Probably don't use this directly, and wrap it in a service specific to that event source
  *
- * This handles when there's multiple backend instances by assigning unique client ids.
+ * This handles when there's multiple backend instances by assigning unique client ids to each connection.
  * When one instance wants to send to a client, it publishes to a Redis channel for the client.
  * All instances listen to Redis, and if they are the one managing that client, they send the msg.
  *
  * Rooms with client metadata are also maintained in Redis key/value store.
  */
 @Injectable()
-export class SSEService<T> {
+export class SSEService<T> implements OnModuleDestroy {
   // Clients connected to this instance of the backend
-  private clientsConnectedDirectly: Record<number, Response> = {};
+  private directConnnections: Record<string, Connection> = {};
 
   constructor(private readonly redisService: RedisService) {
     const redisSub = this.redisService.getClient('sub');
 
     // If channel is managed by this instance, send the message to the Response object.
     redisSub.on('message', (channel, message) => {
-      console.log('MESSAGE');
       const id = /sse::client-(\d+)/.exec(channel);
-      console.log(id, Object.keys(this.clientsConnectedDirectly));
-      if (id && id[1] in this.clientsConnectedDirectly) {
-        this.clientsConnectedDirectly[id[1]].write(`data: ${message}\n\n`);
+      if (id && id[1] in this.directConnnections) {
+        this.directConnnections[id[1]].res.write(`data: ${message}\n\n`);
       }
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    // Cleanup all direct connections by removing them from the rooms in redis.
+    await each(Object.values(this.directConnnections), async (conn) => {
+      await conn.cleanup();
     });
   }
 
@@ -56,8 +67,7 @@ export class SSEService<T> {
     const redisSub = this.redisService.getClient('sub');
     const redis = this.redisService.getClient('db');
     // Keep track of responses so we can send sse through them
-    const clientId = await redis.incr('client::id');
-    this.clientsConnectedDirectly[clientId] = client.res;
+    const clientId = await redis.incr('sse::client::id');
     // Subscribe to the redis channel for this client
     await redisSub.subscribe(this.idToChannel(clientId));
 
@@ -68,10 +78,19 @@ export class SSEService<T> {
     } as RedisClientInfo<T>);
     await redis.sadd(room, clientInfo);
 
+    // Keep track of response object in direct connections
+    this.directConnnections[clientId] = {
+      res: client.res,
+      cleanup: async () => {
+        // Remove from the redis room
+        await redis.srem(room, clientInfo);
+      },
+    };
+
     // Remove dead connections!
     client.res.socket.on('end', async () => {
-      delete this.clientsConnectedDirectly[clientId];
-      await redis.srem(room, clientInfo);
+      await this.directConnnections[clientId].cleanup();
+      delete this.directConnnections[clientId];
     });
   }
 
@@ -84,14 +103,14 @@ export class SSEService<T> {
     const redis = this.redisService.getClient('db');
     const roomInfo = await redis.smembers(room);
     if (room) {
-      const clients: RedisClientInfo<T>[] = roomInfo.map(s => JSON.parse(s));
+      const clients: RedisClientInfo<T>[] = roomInfo.map((s) => JSON.parse(s));
       console.log(`sending sse to ${clients.length} clients in ${room}`);
       console.time(`sending sse time: `);
       apm.startTransaction('sse');
-      for (const { clientId, metadata } of clients) {
+      await each(clients, async ({ clientId, metadata }) => {
         const toSend = serialize(await payload(metadata));
         await redisPub.publish(this.idToChannel(clientId), toSend);
-      }
+      });
       apm.endTransaction();
       console.timeEnd(`sending sse time: `);
     }

--- a/packages/server/src/sse/sse.service.ts
+++ b/packages/server/src/sse/sse.service.ts
@@ -50,7 +50,7 @@ export class SSEService<T> implements OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     // Cleanup all direct connections by removing them from the rooms in redis.
-    await each(Object.values(this.directConnnections), async (conn) => {
+    await each(Object.values(this.directConnnections), async conn => {
       await conn.cleanup();
     });
   }
@@ -84,6 +84,7 @@ export class SSEService<T> implements OnModuleDestroy {
       cleanup: async () => {
         // Remove from the redis room
         await redis.srem(room, clientInfo);
+        await redisSub.unsubscribe(this.idToChannel(clientId));
       },
     };
 
@@ -103,7 +104,7 @@ export class SSEService<T> implements OnModuleDestroy {
     const redis = this.redisService.getClient('db');
     const roomInfo = await redis.smembers(room);
     if (room) {
-      const clients: RedisClientInfo<T>[] = roomInfo.map((s) => JSON.parse(s));
+      const clients: RedisClientInfo<T>[] = roomInfo.map(s => JSON.parse(s));
       console.log(`sending sse to ${clients.length} clients in ${room}`);
       console.time(`sending sse time: `);
       apm.startTransaction('sse');

--- a/packages/server/test/util/testUtils.ts
+++ b/packages/server/test/util/testUtils.ts
@@ -10,6 +10,7 @@ import { addGlobalsToApp } from '../../src/bootstrap';
 import { TwilioService } from '../../src/notification/twilio/twilio.service';
 import { mocked } from 'ts-jest/utils';
 import { NotificationService } from 'notification/notification.service';
+import { RedisModule } from 'nestjs-redis';
 
 export interface SupertestOptions {
   userId?: number;
@@ -48,7 +49,17 @@ export function setupIntegrationTest(
 
   beforeAll(async () => {
     let testModuleBuilder = Test.createTestingModule({
-      imports: [module, LoginModule, TestTypeOrmModule, TestConfigModule],
+      imports: [
+        module,
+        LoginModule,
+        TestTypeOrmModule,
+        TestConfigModule,
+        RedisModule.register([
+          { name: 'pub' },
+          { name: 'sub' },
+          { name: 'db' },
+        ]),
+      ],
     })
       .overrideProvider(TwilioService)
       .useValue(mockTwilio);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,6 +1668,15 @@
     webpack "4.43.0"
     webpack-node-externals "1.7.2"
 
+"@nestjs/common@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-6.3.1.tgz#222f25251eb1b67c6e552e00b266048daa569bbc"
+  integrity sha512-uuI/CCe6MFISMX+fSpkRvvQ6CBlXW89+5wfiveQ22AzAxgqGLAyWvNVHUE8F+zev7QDbxbY9vfPtm8CE5kiJVQ==
+  dependencies:
+    axios "0.19.0"
+    cli-color "1.4.0"
+    uuid "3.3.2"
+
 "@nestjs/common@^7.4.0":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-7.4.2.tgz#f1ceff01a7b2c77094726944f55d907a2196bfe1"
@@ -1689,6 +1698,19 @@
     lodash.get "4.4.2"
     lodash.set "4.3.2"
     uuid "8.1.0"
+
+"@nestjs/core@^6.6.7":
+  version "6.11.11"
+  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-6.11.11.tgz#2b97a3e9c2a853f5693ed84daf81c1ee3b2782b4"
+  integrity sha512-ewUy2rjiRWi6SziI5gXZnlat7PfnVklL3tusnU1qqtUm74cPY1Zre+zDCJ27P/+B7sFJHbkFfpi0qQP2pQv9jQ==
+  dependencies:
+    "@nuxtjs/opencollective" "0.2.2"
+    fast-safe-stringify "2.0.7"
+    iterare "1.2.0"
+    object-hash "2.0.3"
+    path-to-regexp "3.2.0"
+    tslib "1.11.1"
+    uuid "7.0.1"
 
 "@nestjs/core@^7.4.0":
   version "7.4.2"
@@ -2398,6 +2420,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ioredis@^4.0.4":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.17.9.tgz#b11e4768a40ce6ae8d0c8b1266feb98e9dbfd999"
+  integrity sha512-YVLcCDQXaQRMK6Lut2f7KaiU2sV2dEN57AmZTtcZW/TXYv3wKwZTV87oUaA/IAI1Xk4s+d+kXLlCJkGAycfpHw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2653,6 +2682,11 @@
   integrity sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==
   dependencies:
     source-map "^0.6.1"
+
+"@types/uuid@^3.4.4":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
+  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
 
 "@types/validator@13.0.0":
   version "13.0.0"
@@ -3668,6 +3702,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 axios@0.19.2, axios@^0.19.0, axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -4507,6 +4549,18 @@ clean-stack@^3.0.0:
   dependencies:
     escape-string-regexp "4.0.0"
 
+cli-color@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-1.4.0.tgz#7d10738f48526824f8fe7da51857cb0f572fe01f"
+  integrity sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==
+  dependencies:
+    ansi-regex "^2.1.1"
+    d "1"
+    es5-ext "^0.10.46"
+    es6-iterator "^2.0.3"
+    memoizee "^0.4.14"
+    timers-ext "^0.1.5"
+
 cli-color@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.0.tgz#11ecfb58a79278cf6035a60c54e338f9d837897c"
@@ -4683,6 +4737,11 @@ clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
 
 co@^4.6.0:
   version "4.6.0"
@@ -5675,6 +5734,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+denque@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -7899,6 +7963,22 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ioredis@^4.2.0:
+  version "4.19.4"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.19.4.tgz#11112005f87ad3acac247ada3b22eb31b947f7c7"
+  integrity sha512-3haQWw9dpEjcfVcRktXlayVNrrqvvc2io7Q/uiV2UsYw8/HC2YwwJr78Wql7zu5bzwci0x9bZYA69U7KkevAvw==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.6.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -7961,6 +8041,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.2.0:
   version "1.2.0"
@@ -8330,6 +8415,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterare@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/iterare/-/iterare-1.2.0.tgz#7427f5ed45986e4b73e2fea903579f1117f3dd15"
+  integrity sha512-RxMV9p/UzdK0Iplnd8mVgRvNdXlsTOiuDrqMRnDi3wIhbT+JP4xDquAX9ay13R3CH72NBzQ91KWe0+C168QAyQ==
 
 iterare@1.2.1:
   version "1.2.1"
@@ -9155,6 +9245,16 @@ lodash.compact@^3.0.1:
   resolved "https://registry.yarnpkg.com/lodash.compact/-/lodash.compact-3.0.1.tgz#540ce3837745975807471e16b4a2ba21e7256ca5"
   integrity sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -9929,6 +10029,20 @@ nestjs-command@^1.5.0:
     lodash.flattendeep "^4.4.0"
     yargs "^12.0.1"
 
+nestjs-redis@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/nestjs-redis/-/nestjs-redis-1.2.8.tgz#0b62a533b3abf7fad18e4bd2f0c8f19845d56582"
+  integrity sha512-h3lDq/F4xbA++1OY63Lh2LjJgdJ3RvCPFbM+oRbs5M4Ep/9zgWwtfaVlcx31al/wBXUeaJ4HTNv5IAQZLkdIBA==
+  dependencies:
+    "@nestjs/common" "6.3.1"
+    "@nestjs/core" "^6.6.7"
+    "@types/ioredis" "^4.0.4"
+    "@types/uuid" "^3.4.4"
+    ioredis "^4.2.0"
+    reflect-metadata "^0.1.12"
+    rxjs "^6.2.2"
+    uuid "^3.3.2"
+
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
@@ -10611,7 +10725,7 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-map@^2.0.0:
+p-map@^2.0.0, p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
@@ -12404,6 +12518,23 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+redis-commands@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.6.0.tgz#36d4ca42ae9ed29815cdb30ad9f97982eba1ce23"
+  integrity sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
 reduce-css-calc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
@@ -12420,7 +12551,7 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-reflect-metadata@^0.1.13:
+reflect-metadata@^0.1.12, reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
@@ -12857,6 +12988,13 @@ rxjs@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.2.2:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -13492,6 +13630,11 @@ stacktrace-parser@0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
+
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 start-server-webpack-plugin@^2.2.5:
   version "2.2.5"
@@ -14311,6 +14454,11 @@ tsconfig-paths@3.9.0, tsconfig-paths@^3.4.0, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
 tslib@1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -14705,6 +14853,16 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.1.tgz#95ed6ff3d8c881cbf85f0f05cc3915ef994818ef"
+  integrity sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA==
 
 uuid@8.0.0:
   version "8.0.0"


### PR DESCRIPTION
# Goal
Use PM2 to run 2 instances of the app in cluster mode, load balancing between them. `prod:start` then uses `reload` instead of `restart`, which will restart them one at a time, waiting for one to come up before starting the next. This results in having 1 instance of the app up at all times.

We will now run 2 instances of the app in parallel. This will help us scale the app out horizontally in the future, to handle more users.

# Implications
HOWEVER, running a system like this means we can NO LONGER persist things in memory and expect them to be the same on subsequent requests, since requests are split across multiple instances that may restart randomly. This new constraint so far just affects SSE, so much of this PR is just rerwriting SSE to use Redis to pub/sub between instances of the backend and send SSE messages no matter which backend instance the clients are connected to.

# Deployment
Before deploying, we must install Redis on staging and production.
Upon deploying, we must do `yarn prod:stop` and `yarn prod:start` to fully refresh pm2.
