### PR TITLE
Help Next slight UX improvement

### DIFF
--- a/cypress/integration/ta/student_question.spec.js
+++ b/cypress/integration/ta/student_question.spec.js
@@ -70,7 +70,7 @@ describe("TA interacts with student question", () => {
     cy.get("[data-cy='help-next']").click();
 
     // See that the students question is shown as helping
-    cy.contains("Helping");
+    cy.get("[data-cy='finish-helping-button']").should("exist");
     cy.percySnapshot("TA Queue Page - Helping Student Banner");
   });
 

--- a/packages/app/components/Queue/TA/TAQueueListDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueListDetail.tsx
@@ -87,6 +87,10 @@ export default function TAQueueListDetail({
   if (selectedQuestionId && !selectedQuestion) {
     setSelectedQuestionId(null);
   }
+  // set current question to first helping question if none is selected (used when help next is clicked)
+  if (!selectedQuestionId && helpingQuestions.length) {
+    setSelectedQuestionId(helpingQuestions[0].id);
+  }
 
   if (!questions) {
     return <Skeleton />;


### PR DESCRIPTION
When the "Help Next" button is clicked it does not select the question that is TA is now helping in the list detail view. This means the TA has to click on the question in the currently helping section and then click finish helping in the question detail pane. This is not a big deal but I thought fixing it would slightly improve the UX for TAs.