### PR TITLE
Add settings confirmation message

### DIFF
--- a/packages/app/components/Settings/NotificationsSettings.tsx
+++ b/packages/app/components/Settings/NotificationsSettings.tsx
@@ -48,6 +48,9 @@ export default function NotificationsSettings(): ReactElement {
     try {
       const newProfile = await editProfile(value);
       form.setFieldsValue(newProfile);
+      message.success(
+        "Your notification settings have been sucsessfully updated"
+      );
     } catch (e) {
       if (
         e.response?.status === 400 &&

--- a/packages/app/components/Settings/ProfileSettings.tsx
+++ b/packages/app/components/Settings/ProfileSettings.tsx
@@ -1,6 +1,6 @@
 import { API } from "@koh/api-client";
 import { UpdateProfileParams } from "@koh/common";
-import { Button, Form, Input } from "antd";
+import { Button, Form, Input, message } from "antd";
 import { pick } from "lodash";
 import React, { ReactElement } from "react";
 import useSWR from "swr";
@@ -23,6 +23,7 @@ export default function ProfileSettings(): ReactElement {
     const value = await form.validateFields();
     const newProfile = await editProfile(value);
     form.setFieldsValue(newProfile);
+    message.success("Your profile settings have been sucsessfully updated");
   };
 
   return profile ? (


### PR DESCRIPTION
Another student mentioned that it was unclear that the "OK" button was working on the settings page because there was no feedback on the screen telling them it worked, so I added a message to help clear up the UX
