### PR TITLE
User course override

### DIFF
--- a/packages/server/migration/1611958171853-UserCourseOverride.ts
+++ b/packages/server/migration/1611958171853-UserCourseOverride.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserCourseOverride1611958171853 implements MigrationInterface {
+  name = 'UserCourseOverride1611958171853';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_course_model" ADD "override" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_course_model" DROP COLUMN "override"`,
+    );
+  }
+}

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -64,10 +64,14 @@ export class LoginCourseService {
     // Delete "stale" user courses
     for (const previousCourse of user.courses) {
       if (
-        previousCourse.course.enabled &&
-        !this.hasUserCourse(userCourses, previousCourse)
+        !this.hasUserCourse(userCourses, previousCourse) &&
+        previousCourse.course.enabled
       ) {
-        previousCourse.remove();
+        if (!previousCourse.override) {
+          previousCourse.remove();
+        } else {
+          userCourses.push(previousCourse);
+        }
       }
     }
 
@@ -94,8 +98,12 @@ export class LoginCourseService {
   ): Promise<UserCourseModel> {
     let userCourse: UserCourseModel;
     userCourse = await UserCourseModel.findOne({
-      where: { userId, courseId, role },
+      where: { userId, courseId },
     });
+    if (userCourse.override && userCourse.role === role) {
+      userCourse.override = false;
+      await userCourse.save();
+    }
     if (!userCourse) {
       userCourse = await UserCourseModel.create({
         userId,

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -100,7 +100,7 @@ export class LoginCourseService {
     userCourse = await UserCourseModel.findOne({
       where: { userId, courseId },
     });
-    if (userCourse.override && userCourse.role === role) {
+    if (userCourse && userCourse.override && userCourse.role === role) {
       userCourse.override = false;
       await userCourse.save();
     }

--- a/packages/server/src/profile/user-course.entity.ts
+++ b/packages/server/src/profile/user-course.entity.ts
@@ -31,4 +31,7 @@ export class UserCourseModel extends BaseEntity {
 
   @Column({ type: 'enum', enum: Role, default: Role.STUDENT })
   role: Role;
+
+  @Column({ default: false })
+  override: boolean;
 }

--- a/packages/server/test/login.integration.ts
+++ b/packages/server/test/login.integration.ts
@@ -232,6 +232,7 @@ describe('Login Integration', () => {
         expect(fundiesUserCourse).toEqual({
           courseId: 1,
           id: 1,
+          override: false,
           role: 'student',
           userId: 1,
         });
@@ -335,6 +336,7 @@ describe('Login Integration', () => {
         expect(fundiesUserCourse).toEqual({
           courseId: 1,
           id: 1,
+          override: false,
           role: 'student',
           userId: 1,
         });
@@ -383,7 +385,13 @@ describe('Login Integration', () => {
           overrideCourse.id,
         );
         expect(overrideStillExists).toBeDefined();
-        expect(overrideStillExists).toStrictEqual(overrideCourse);
+        expect(overrideStillExists).toEqual({
+          courseId: overrideCourse.courseId,
+          id: overrideCourse.id,
+          override: overrideCourse.override,
+          role: overrideCourse.role,
+          userId: overrideCourse.userId,
+        });
 
         const totalUserCoursesUpdated = await UserCourseModel.count();
         expect(totalUserCoursesUpdated).toEqual(3);

--- a/packages/server/test/login.integration.ts
+++ b/packages/server/test/login.integration.ts
@@ -279,6 +279,115 @@ describe('Login Integration', () => {
         const totalUserCoursesUpdated = await UserCourseModel.count();
         expect(totalUserCoursesUpdated).toEqual(2);
       });
+
+      it('respects user course overrides', async () => {
+        await supertest()
+          .post('/khoury_login')
+          .send({
+            email: 'stenzel.w@northeastern.edu',
+            campus: 1,
+            first_name: 'Will',
+            last_name: 'Stenzel',
+            photo_url: '',
+            courses: [
+              {
+                course: 'CS 2510',
+                crn: 12345,
+                accelerated: false,
+                section: 1,
+                semester: '000',
+                title: 'Fundamentals of Computer Science II',
+              },
+              {
+                course: 'CS 2510',
+                crn: 24680,
+                accelerated: true,
+                section: 2,
+                semester: '000',
+                title: 'Fundamentals of Computer Science II',
+              },
+            ],
+            ta_courses: [
+              {
+                course: 'CS 2500',
+                crn: 12312,
+                accelerated: false,
+                section: 55555,
+                semester: '000',
+                title: 'Fundamentals of Computer Science I',
+              },
+            ],
+          })
+          .expect(201);
+
+        const user = await UserModel.findOne({
+          where: { email: 'stenzel.w@northeastern.edu' },
+          relations: ['courses'],
+        });
+
+        const overrideCourse = await UserCourseFactory.create({
+          override: true,
+        });
+
+        const fundiesUserCourse = await UserCourseModel.findOne({
+          where: { user, course },
+        });
+        expect(fundiesUserCourse).toEqual({
+          courseId: 1,
+          id: 1,
+          role: 'student',
+          userId: 1,
+        });
+
+        const totalUserCourses = await UserCourseModel.count();
+        expect(totalUserCourses).toEqual(4);
+
+        // After dropping fundies II, user logs in again
+        await supertest()
+          .post('/khoury_login')
+          .send({
+            email: 'stenzel.w@northeastern.edu',
+            campus: 1,
+            first_name: 'Will',
+            last_name: 'Stenzel',
+            photo_url: '',
+            courses: [
+              {
+                course: 'CS 2510',
+                crn: 24680,
+                accelerated: true,
+                section: 2,
+                semester: '000',
+                title: 'Fundamentals of Computer Science II',
+              },
+            ],
+            ta_courses: [
+              {
+                course: 'CS 2500',
+                crn: 12312,
+                accelerated: false,
+                section: 55555,
+                semester: '000',
+                title: 'Fundamentals of Computer Science I',
+              },
+            ],
+          })
+          .expect(201);
+
+        const noUserCourse = await UserCourseModel.findOne(
+          fundiesUserCourse.id,
+        );
+        expect(noUserCourse).toBeUndefined();
+
+        const overrideStillExists = await UserCourseModel.findOne(
+          overrideCourse.id,
+        );
+        expect(overrideStillExists).toBeDefined();
+        expect(overrideStillExists).toStrictEqual(overrideCourse);
+
+        const totalUserCoursesUpdated = await UserCourseModel.count();
+        expect(totalUserCoursesUpdated).toEqual(3);
+      });
     });
 
     const setupTAAndProfessorCourses = async () => {

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -53,7 +53,8 @@ export const CourseSectionFactory = new Factory(CourseSectionMappingModel)
 export const UserCourseFactory = new Factory(UserCourseModel)
   .assocOne('user', UserFactory)
   .assocOne('course', CourseFactory)
-  .attr('role', Role.STUDENT);
+  .attr('role', Role.STUDENT)
+  .attr('override', false);
 
 export const QueueFactory = new Factory(QueueModel)
   .attr('room', 'Online')


### PR DESCRIPTION
Add an `override` field to the UserCourse model, so that UserCourses which have `override = true` will not be wiped away when re-fetching khoury data. 