### PR TITLE
Hot fix issue with queue section not showing for professors

### DIFF
--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -74,7 +74,7 @@ export class CourseController {
     if (userCourseModel.role === Role.PROFESSOR) {
       course.queues = await async.filter(
         course.queues,
-        async (q) => q.isProfessorQueue || (await q.checkIsOpen()),
+        async (q) => (await q.checkIsOpen()) || q.isProfessorQueue,
       );
     } else {
       course.queues = await async.filter(


### PR DESCRIPTION
This issue was caused by not calling the `checkIsOpen()` function if a queue was a professor queue. The `checkIsOpen()` mutates the queue by adding an `isOpen` attribute to it which is not very clear and something we should probably change in the future. 
