### PR TITLE
Fix issue with checking for open office hours

### DIFF
--- a/packages/server/src/queue/queue.entity.spec.ts
+++ b/packages/server/src/queue/queue.entity.spec.ts
@@ -1,7 +1,11 @@
 import { ClosedQuestionStatus, OpenQuestionStatus } from '@koh/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Connection } from 'typeorm';
-import { QuestionFactory, QueueFactory } from '../../test/util/factories';
+import {
+  OfficeHourFactory,
+  QuestionFactory,
+  QueueFactory,
+} from '../../test/util/factories';
 import { TestTypeOrmModule } from '../../test/util/testUtils';
 import { QueueModel } from './queue.entity';
 
@@ -56,5 +60,44 @@ describe('queue entity', () => {
     await queue.addQueueSize();
 
     expect(queue.queueSize).toBe(2);
+  });
+
+  it('areTheirOfficeHoursRightNow works when oh time spans across midnight', async () => {
+    const oh = await OfficeHourFactory.create({
+      startTime: new Date('2020-12-13T22:53:57.254Z'),
+      endTime: new Date('2020-12-14T00:08:57.254Z'),
+    });
+
+    const queue = await QueueFactory.create({
+      officeHours: [oh],
+    });
+
+    // Should be false when time is 10 min before office hours
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-13T22:40:00.254Z'),
+      ),
+    ).toBeFalsy();
+
+    // Should return true when time is within 10 min of the start of office hours
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-13T22:50:00.254Z'),
+      ),
+    ).toBeTruthy();
+
+    // Should be true when time is during office hours and before midnight UTC
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-13T22:58:57.254Z'),
+      ),
+    ).toBeTruthy();
+
+    // Should be true when time is during office hours and after midnight UTC
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-14T00:04:00.254Z'),
+      ),
+    ).toBeTruthy();
   });
 });

--- a/packages/server/src/queue/queue.entity.spec.ts
+++ b/packages/server/src/queue/queue.entity.spec.ts
@@ -72,32 +72,78 @@ describe('queue entity', () => {
       officeHours: [oh],
     });
 
-    // Should be false when time is 10 min before office hours
+    // greater than 10 min before office hours start
     expect(
       await queue.areThereOfficeHoursRightNow(
         new Date('2020-12-13T22:40:00.254Z'),
       ),
     ).toBeFalsy();
 
-    // Should return true when time is within 10 min of the start of office hours
+    // whithin 10 min of office hours start
     expect(
       await queue.areThereOfficeHoursRightNow(
         new Date('2020-12-13T22:50:00.254Z'),
       ),
     ).toBeTruthy();
 
-    // Should be true when time is during office hours and before midnight UTC
+    // during office hours and before midnight
     expect(
       await queue.areThereOfficeHoursRightNow(
         new Date('2020-12-13T22:58:57.254Z'),
       ),
     ).toBeTruthy();
 
-    // Should be true when time is during office hours and after midnight UTC
+    // during office hours and after midnight
     expect(
       await queue.areThereOfficeHoursRightNow(
         new Date('2020-12-14T00:04:00.254Z'),
       ),
     ).toBeTruthy();
+
+    // after office hours
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-14T00:10:00.254Z'),
+      ),
+    ).toBeFalsy();
+  });
+
+  it('areTheirOfficeHoursRightNow works when office hours are during normal hours', async () => {
+    const oh = await OfficeHourFactory.create({
+      startTime: new Date('2020-12-10T09:00:00.254Z'),
+      endTime: new Date('2020-12-10T10:00:00.254Z'),
+    });
+
+    const queue = await QueueFactory.create({
+      officeHours: [oh],
+    });
+
+    // greater than 10 min before office hours start
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-10T08:40:00.254Z'),
+      ),
+    ).toBeFalsy();
+
+    // whithin 10 min of office hours start
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-10T08:52:00.254Z'),
+      ),
+    ).toBeTruthy();
+
+    // during office hours
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-10T09:23:00.254Z'),
+      ),
+    ).toBeTruthy();
+
+    // after office hours
+    expect(
+      await queue.areThereOfficeHoursRightNow(
+        new Date('2020-12-10T10:30:00.254Z'),
+      ),
+    ).toBeFalsy();
   });
 });

--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -75,10 +75,9 @@ export class QueueModel extends BaseEntity {
     return this.isOpen;
   }
 
-  async areThereOfficeHoursRightNow(): Promise<boolean> {
-    const now = new Date();
+  async areThereOfficeHoursRightNow(now = new Date()): Promise<boolean> {
     const MS_IN_MINUTE = 60000;
-    const ohs = await this.getOfficeHours();
+    const ohs = await this.getOfficeHours(now);
     return !!ohs.find(
       (e) =>
         e.startTime.getTime() - 10 * MS_IN_MINUTE < now.getTime() &&
@@ -111,15 +110,13 @@ export class QueueModel extends BaseEntity {
   }
 
   // Get Office hours in a 72hr window around now, snapped to midnight
-  private async getOfficeHours(): Promise<OfficeHourModel[]> {
-    const now = new Date();
-
+  private async getOfficeHours(now = new Date()): Promise<OfficeHourModel[]> {
     const lowerBound = new Date(now);
-    lowerBound.setUTCHours(now.getUTCHours() - 24);
+    lowerBound.setUTCHours(now.getUTCHours() - 30);
     lowerBound.setUTCHours(0, 0, 0, 0);
 
     const upperBound = new Date(now);
-    upperBound.setUTCHours(now.getUTCHours() + 24);
+    upperBound.setUTCHours(now.getUTCHours() + 30);
     upperBound.setUTCHours(0, 0, 0, 0);
 
     return await OfficeHourModel.find({


### PR DESCRIPTION
# Description
I noticed there was an issue with checking for open office hours when the time spanned across midnight cause all of our cypress tests would randomly fail every so often. This was caused by us not accounting for the fact that the EST timezone is six hours different from UTC. With the help of @liustanley we updated the code that finds office hours to look in a wider time range to account for this. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [ ] Created tests for both when office hour are at odd times and at normal times


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
