### PR TITLE
Removing Any From the Table and Graph Insight Types

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -597,7 +597,7 @@ export type PossibleOutputTypes =
 export type SimpleDisplayOutputType = number | string;
 
 export type BarChartOutputType = {
-  data: any[];
+  data: StringMap[];
   xField: string;
   yField: string;
   seriesField: string;
@@ -606,8 +606,12 @@ export type BarChartOutputType = {
 };
 
 export type SimpleTableOutputType = {
-  dataSource: any[];
-  columns: any[];
+  dataSource: StringMap[];
+  columns: StringMap[];
+};
+
+export type StringMap = {
+  [key: string]: string;
 };
 
 export type DateRangeType = {


### PR DESCRIPTION
# Description

Instead of having an any[], we can have a strict type for an object whose keys are strings and whose values are as well. 

Closes #609 

## Type of change

Types Update

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Ran the tests with the existing insights and they passed. 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
