### PR TITLE
anonymize student helping names to other students

### DIFF
--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -3,10 +3,8 @@ import { Badge, Col, Row } from "antd";
 import { useRouter } from "next/router";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
-import { useCourse } from "../../hooks/useCourse";
 import { useQuestions } from "../../hooks/useQuestions";
 import { useQueue } from "../../hooks/useQueue";
-import { useRoleInCourse } from "../../hooks/useRoleInCourse";
 import { formatWaitTime } from "../../utils/TimeUtil";
 import { KOHAvatar } from "../common/SelfAvatar";
 import { RenderEvery } from "../RenderEvery";
@@ -124,17 +122,11 @@ interface HelpingForProps {
   helpedAt: Date;
 }
 function HelpingFor({ studentName, helpedAt }: HelpingForProps): ReactElement {
-  const router = useRouter();
-  const { cid } = router.query;
-  const role = useRoleInCourse(Number(cid));
-
   return (
     <RenderEvery
       render={() => (
         <span>
-          Helping{" "}
-          {role == Role.TA ? <BlueSpan>{studentName}</BlueSpan> : "a student"}{" "}
-          for{" "}
+          Helping <BlueSpan>{studentName ?? "a student"}</BlueSpan> for{" "}
           <BlueSpan>
             {formatWaitTime((Date.now() - helpedAt.getTime()) / 60000)}
           </BlueSpan>

--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -1,9 +1,12 @@
-import { Question } from "@koh/common";
+import { Question, Role } from "@koh/common";
 import { Badge, Col, Row } from "antd";
+import { useRouter } from "next/router";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
+import { useCourse } from "../../hooks/useCourse";
 import { useQuestions } from "../../hooks/useQuestions";
 import { useQueue } from "../../hooks/useQueue";
+import { useRoleInCourse } from "../../hooks/useRoleInCourse";
 import { formatWaitTime } from "../../utils/TimeUtil";
 import { KOHAvatar } from "../common/SelfAvatar";
 import { RenderEvery } from "../RenderEvery";
@@ -16,6 +19,7 @@ interface StatusRowProps {
  */
 export function TAStatuses({ queueId }: StatusRowProps): ReactElement {
   const { questions } = useQuestions(queueId);
+
   const {
     queue: { staffList },
   } = useQueue(queueId);
@@ -120,11 +124,15 @@ interface HelpingForProps {
   helpedAt: Date;
 }
 function HelpingFor({ studentName, helpedAt }: HelpingForProps): ReactElement {
+  const router = useRouter();
+  const { cid } = router.query;
+  const role = useRoleInCourse(Number(cid));
+
   return (
     <RenderEvery
       render={() => (
         <span>
-          Helping <BlueSpan>{studentName ?? "a student"}</BlueSpan> for{" "}
+          Helping {role == Role.TA ? studentName : "a student"} for{" "}
           <BlueSpan>
             {formatWaitTime((Date.now() - helpedAt.getTime()) / 60000)}
           </BlueSpan>

--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -132,7 +132,9 @@ function HelpingFor({ studentName, helpedAt }: HelpingForProps): ReactElement {
     <RenderEvery
       render={() => (
         <span>
-          Helping {role == Role.TA ? studentName : "a student"} for{" "}
+          Helping{" "}
+          {role == Role.TA ? <BlueSpan>{studentName}</BlueSpan> : "a student"}{" "}
+          for{" "}
           <BlueSpan>
             {formatWaitTime((Date.now() - helpedAt.getTime()) / 60000)}
           </BlueSpan>

--- a/packages/app/components/Queue/TAStatuses.tsx
+++ b/packages/app/components/Queue/TAStatuses.tsx
@@ -1,6 +1,5 @@
-import { Question, Role } from "@koh/common";
+import { Question } from "@koh/common";
 import { Badge, Col, Row } from "antd";
-import { useRouter } from "next/router";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
 import { useQuestions } from "../../hooks/useQuestions";
@@ -17,7 +16,6 @@ interface StatusRowProps {
  */
 export function TAStatuses({ queueId }: StatusRowProps): ReactElement {
   const { questions } = useQuestions(queueId);
-
   const {
     queue: { staffList },
   } = useQueue(queueId);

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -92,6 +92,21 @@ export class QueueService {
         );
       });
 
+      newLQR.questionsGettingHelp = questions.questionsGettingHelp.map(
+        (question) => {
+          const newQ = new Question();
+          Object.assign(newQ, question);
+          const creator =
+            question.creator.id === userId
+              ? question.creator
+              : pick(question.creator, ['id']);
+          // classToClass transformer will apply the @Excludes
+          return classToClass<Question>(
+            QuestionModel.create({ ...question, creator }),
+          );
+        },
+      );
+
       newLQR.yourQuestion = await QuestionModel.findOne({
         relations: ['creator', 'taHelped'],
         where: {

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -94,8 +94,6 @@ export class QueueService {
 
       newLQR.questionsGettingHelp = questions.questionsGettingHelp.map(
         (question) => {
-          const newQ = new Question();
-          Object.assign(newQ, question);
           const creator =
             question.creator.id === userId
               ? question.creator


### PR DESCRIPTION
# Description

Students can currently see the names of the other students that are being helped. I made it so that only TAs can see who other TAs are helping by anonymizing the questionsGettingHelp on the backend

**TA View**
![image](https://user-images.githubusercontent.com/59672089/111554806-6c15ac00-875d-11eb-8267-a2a045c1d185.png)


**Student Being Helped** 
![image](https://user-images.githubusercontent.com/59672089/111554928-a717df80-875d-11eb-9a33-87302d5051cb.png)


**Other Student In Course**
![image](https://user-images.githubusercontent.com/59672089/111555164-31604380-875e-11eb-9b8a-80ce83a4f186.png)


Closes # (issue number) #604 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Visually on the Frontend through multiple user's views of the screen, and through the network requests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
