### PR TITLE
Fix clean queue bug

### DIFF
--- a/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
@@ -183,8 +183,14 @@ describe('QueueService', () => {
     it('correctly cleans queues from current course sections', async () => {
       const cleanQueueSpy = jest.spyOn(service, 'cleanQueue');
 
-      const queue1 = await QueueFactory.create({ notes: 'clean me', officeHours: [] });
-      const queue2 = await QueueFactory.create({ notes: 'I could also use a clean', officeHours: [] });
+      const queue1 = await QueueFactory.create({
+        notes: 'clean me',
+        officeHours: [],
+      });
+      const queue2 = await QueueFactory.create({
+        notes: 'I could also use a clean',
+        officeHours: [],
+      });
       const course = await CourseFactory.create({ queues: [queue1, queue2] });
       await CourseSectionFactory.create({ course });
 
@@ -201,7 +207,7 @@ describe('QueueService', () => {
     it('does not clean queues that are not related to current course section', async () => {
       const cleanQueueSpy = jest.spyOn(service, 'cleanQueue');
 
-      await QueueFactory.create({ notes: 'clean me'});
+      await QueueFactory.create({ notes: 'clean me' });
 
       await service.cleanAllQueues();
       expect(cleanQueueSpy).toHaveBeenCalledTimes(0);

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -25,12 +25,17 @@ export class QueueCleanService {
     const activeCourseSections = await CourseSectionMappingModel.getRepository()
       .createQueryBuilder('course_section')
       .leftJoinAndSelect('course_section.course', 'course')
-      .leftJoinAndSelect('course.queues', 'queues').getMany();
+      .leftJoinAndSelect('course.queues', 'queues')
+      .getMany();
 
-    const uniqueActiveCourses = new Set(activeCourseSections.map(section => section.course));
+    const uniqueActiveCourses = new Set(
+      activeCourseSections.map((section) => section.course),
+    );
 
     const uniqueQueuesToBeCleaned = [];
-    uniqueActiveCourses.forEach(course => uniqueQueuesToBeCleaned.push(...course.queues))
+    uniqueActiveCourses.forEach((course) =>
+      uniqueQueuesToBeCleaned.push(...course.queues),
+    );
 
     await Promise.all(
       uniqueQueuesToBeCleaned.map((queue) => this.cleanQueue(queue.id)),


### PR DESCRIPTION
# Description

Previously our `cleanAllQueues` function was attempting to clean only the queues which had questions with an `OpenQuestionStatus`. This meant we were not able to clean queues that had questions in `LimboStatus`. 

I decided to update the `cleanAllQueues` function to clean all queues that are attached to a course that is currently active. This we not only will we clean all the `Open` and `Limbo` status questions from the queue but we will also reset the queue notes for all the active queues (which I think we want to do). 

Closes #631 #632

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests to the for the `cleanAllQueues` function 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
