### PR TITLE
MUTLI DAY TIMES FOR EVENTS THAT START ON ONE DAY AND END ON ANOTHER

### DIFF
--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -46,6 +46,7 @@ export default function SchedulePanel({
         scrollToTime={
           new Date(today.getFullYear(), today.getMonth(), today.getDate(), 8)
         }
+        showMultiDayTimes
       />
       {role === Role.PROFESSOR && <UpdateCalendarButton courseId={courseId} />}
     </div>


### PR DESCRIPTION
# Description

Events that end at 12AM EST/EDT show up as daily events rather than timeblocks

**Original:** 
![image](https://user-images.githubusercontent.com/59672089/111076705-c98ecc00-84c3-11eb-9fd7-fc92f96d640a.png)

**Fixed:** 
![image](https://user-images.githubusercontent.com/59672089/111076670-a7954980-84c3-11eb-82e2-d8d3cdf3a7ae.png)


Closes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and wtih tests)
Provide instructions so we can reproduce. 

- [ ] Manually by adding a new OH to the seed between the day and then taking the screenshot 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
