### PR TITLE
Fix LockError when second server tries to scrape

### DIFF
--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -233,7 +233,7 @@ export class IcalService {
 
     const redisDB = await this.redisService.getClient('db');
 
-    const redlock = new Redlock([redisDB]);
+    const redlock = new Redlock([redisDB], { retryCount: 0 });
 
     redlock.on('clientError', function (err) {
       console.error('A redis error has occurred:', err);


### PR DESCRIPTION
# Description

This is a one line PR that sets the retry count for our Redlock instance to 0, meaning that it will treat a failure as the resource being "locked" or (more correctly) "unavailable".

Addresses this error on [Sentry](https://sentry.io/organizations/sandboxnu/issues/2258968235/?environment=production&project=5410042&query=is%3Aunresolved)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I haven't tested this yet, but it shouldn't be a breaking change. We can verify this on staging.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
