### PR TITLE
typed redlock + ignore lib in tsconfig consistently + start of strict null checking

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,6 +88,7 @@
     "@types/passport-jwt": "^3.0.3",
     "@types/readline-sync": "^1.4.3",
     "@types/redis": "^2.8.28",
+    "@types/redlock": "^4.0.1",
     "@types/supertest": "^2.0.8",
     "@types/web-push": "^3.3.0",
     "cross-env": "^7.0.2",

--- a/packages/server/src/admin/credentialValidator.ts
+++ b/packages/server/src/admin/credentialValidator.ts
@@ -1,5 +1,5 @@
-import { AdminUserModel } from './admin-user.entity';
 import { compare } from 'bcrypt';
+import { AdminUserModel } from './admin-user.entity';
 
 export const adminCredentialValidator = {
   inject: [],
@@ -7,7 +7,7 @@ export const adminCredentialValidator = {
     return async function validateCredentials(
       username: string,
       password: string,
-    ): Promise<AdminUserModel> {
+    ): Promise<AdminUserModel | null> {
       const user = await AdminUserModel.findOne({ username });
       if (user) {
         if (await compare(password, user.passwordHash)) {

--- a/packages/server/src/backfill/backfill-phone-notifs.command.ts
+++ b/packages/server/src/backfill/backfill-phone-notifs.command.ts
@@ -31,7 +31,7 @@ export class BackfillPhoneNotifs {
     console.log(`found ${dups.length} dups`);
     toDelete.push(...dups);
 
-    const valid = [];
+    const valid: PhoneNotifModel[] = [];
     let changedNum = 0;
     // change to real number
     const all = await PhoneNotifModel.find({ relations: ['user'] });

--- a/packages/server/src/course/course-roles.guard.ts
+++ b/packages/server/src/course/course-roles.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { RolesGuard } from '../guards/role.guard';
 import { UserModel } from '../profile/user.entity';
 

--- a/packages/server/src/course/course-roles.guard.ts
+++ b/packages/server/src/course/course-roles.guard.ts
@@ -1,6 +1,6 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { UserModel } from '../profile/user.entity';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { RolesGuard } from '../guards/role.guard';
+import { UserModel } from '../profile/user.entity';
 
 @Injectable()
 export class CourseRolesGuard extends RolesGuard {

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -233,7 +233,7 @@ export class IcalService {
 
     const redisDB = await this.redisService.getClient('db');
 
-    const redlock = new Redlock([redisDB], { retryCount: 0 });
+    const redlock = new Redlock([redisDB]);
 
     redlock.on('clientError', function (err) {
       console.error('A redis error has occurred:', err);

--- a/packages/server/src/profile/user.entity.ts
+++ b/packages/server/src/profile/user.entity.ts
@@ -30,7 +30,7 @@ export class UserModel extends BaseEntity {
   lastName: string;
 
   @Column('text', { nullable: true })
-  photoURL: string;
+  photoURL: string | null;
 
   @OneToMany((type) => UserCourseModel, (ucm) => ucm.user)
   @Exclude()

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -10,6 +10,8 @@
     "sourceMap": true,
     "baseUrl": "./src",
     "outDir": "./dist",
-    "incremental": true
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "noEmit": true,
     "isolatedModules": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true
   },
   "exclude": ["**/node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,11 @@
   resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-3.0.0.tgz#851489a9065a067cb7f3c9cbe4ce9bed8bba0876"
   integrity sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==
 
+"@types/bluebird@*":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.33.tgz#d79c020f283bd50bd76101d7d300313c107325fc"
+  integrity sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -2806,6 +2811,13 @@
   integrity sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==
   dependencies:
     "@types/node" "*"
+
+"@types/redlock@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/redlock/-/redlock-4.0.1.tgz#cfa620968f2ebe795f3abeef8e9128f071eeef85"
+  integrity sha512-YrPEPHOgLlWtsg/Ocv/gthGDQpx3HXFPhBvCNuBKBKUoMBzvCjCTC95dmJ0WLZgO+fgTxGQFyk6ZO/+/zG5mRg==
+  dependencies:
+    "@types/bluebird" "*"
 
 "@types/resolve@0.0.8":
   version "0.0.8"


### PR DESCRIPTION
# Description

`redlock` was added without `@types/redlock`. This also makes it so `yarn tsc` ignores `node_modules` consistently (it's kind of useless to check those), and those a little cleanup to start getting ready for strict null checking

Closes (issue number) [i have too many issues]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`yarn tsc`.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
