### PR TITLE
No longer clear queue notes during queue clean

### DIFF
--- a/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
@@ -166,18 +166,6 @@ describe('QueueService', () => {
       await question.reload();
       expect(question.status).toEqual('Stale');
     });
-
-    it('cleaning the queue removes the queue notes', async () => {
-      const ofs = await ClosedOfficeHourFactory.create();
-      const queue = await QueueFactory.create({
-        officeHours: [ofs],
-        notes: 'This note is no longer relevant',
-      });
-
-      await service.cleanQueue(queue.id);
-      await queue.reload();
-      expect(queue.notes).toBe('');
-    });
   });
   describe('cleanAllQueues', () => {
     it.skip('correctly cleans queues from current course sections', async () => {
@@ -198,9 +186,6 @@ describe('QueueService', () => {
 
       await queue1.reload();
       await queue2.reload();
-      expect(queue1.notes).toEqual('');
-      expect(queue2.notes).toEqual('');
-
       expect(cleanQueueSpy).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -65,8 +65,6 @@ export class QueueCleanService {
     });
 
     if (force || !(await queue.checkIsOpen())) {
-      queue.notes = '';
-      await queue.save();
       await this.unsafeClean(queue.id);
     }
   }


### PR DESCRIPTION
# Description

Previously we we're cleaning the queue notes each night for the queues that were getting cleaned. However, we realized some people might want to have an announcement in the queue notes that persists over multiple days so we decided to stop clearing the queue notes during the queue clean. 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated automated tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
