### PR TITLE
Display negative elapsed time as 0

### DIFF
--- a/packages/app/utils/TimeUtil.ts
+++ b/packages/app/utils/TimeUtil.ts
@@ -8,7 +8,7 @@ export function getWaitTime(question: Question): string {
 
 export function formatWaitTime(minutes: number): string {
   const m = Math.floor(minutes);
-  if (!m) {
+  if (m <= 0) {
     return "0 min";
   } else if (m % 60 == 0) {
     return `${Math.floor(m / 60)}hr`;


### PR DESCRIPTION
# Description

Fixes #665 by displaying negative elapsed time as 0 to account for minor time differences between client and server. Prevents negative values from being displayed as the elapsed time.

Closes #665 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce.

Has not been tested yet.

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
