### PR TITLE
Containerized dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@ node_modules
 .git
 dist
 .next
+
+.dockerignore
+Dockerfile
+infrastructure/dev/docker-compose.yml

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,15 +1,17 @@
 ## Installation
 
-1. [Get Docker](https://docs.docker.com/get-docker/) so we can automatically run and setup Postgres
-2. Make sure you have [node](https://nodejs.org/en/download/), [yarn](https://classic.yarnpkg.com/en/docs/install), and [psql](https://blog.timescale.com/tutorials/how-to-install-psql-on-mac-ubuntu-debian-windows/) installed. `yarn -v` should be `1.x.x`. Do not get Yarn 2.
-   Node should also be version 14.x.x. If it's not, install [nvm](https://github.com/nvm-sh/nvm)
-3. Run `yarn install` in this directory to get dependencies
-4. Run `yarn dev:db:up` to start the database via docker. `yarn dev:db:down` will stop it.
-5. Run `psql -U postgres -h localhost` to connect to your postgres instance, and run `CREATE database dev;` and `CREATE database test;` to initialize your databases for development and testing.
-6. Start the app in development with `yarn dev`
-7. Visit the app at http://localhost:3000
+1. [Instal Docker](https://docs.docker.com/get-docker/)
+2. `docker compose -f infrastructure/dev/docker-compose.yml up --build -d`
 
-If you have any questions, feel free to reach out to a member of the team. If you think this document can be improved, make a PR!
+Your app is ready on `http://localhost:3000`
+
+If you have any questions, feel free to reach out to JENNINGS. If you think this document can be improved, make a PR!
+
+### Teardown
+
+```shell
+docker compose -f infrastructure/dev/docker-compose.yml down -v
+```
 
 ## Technologies
 
@@ -45,6 +47,8 @@ Source code is in the `packages` folder.
 The `infrastructure` folder is for docker and other deployment files. You can mostly ignore it.
 
 ## Developing
+
+TODO: translate these into docker commands
 
 Run `yarn dev` at root level to get everything running and hot-reloading. `yarn test` at root level runs all tests, but you can also selectively run tests by running `yarn test` while inside a package. Be sure to have the db running with `yarn dev:db:up` before running dev or tests.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# proof-of-concept, run the entire koh in one container.
+# BTW this is bad. Ideally we should have _one process per container_,
+# i.e. front-end in its own container, back-end in its own container,
+# proxy or whatever other pizaaz in its own container.
+
+FROM node:14
+
+# TODO copy package.jsons and project scaffold w/o src/ folder for caching yarn install
+COPY . .
+
+RUN ["yarn", "install"]
+
+CMD ["yarn", "dev"]

--- a/infrastructure/dev/devProxy.js
+++ b/infrastructure/dev/devProxy.js
@@ -7,12 +7,12 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 const app = express();
 
 const proxy = createProxyMiddleware({
-  target: "http://localhost:3001",
+  target: "http://app:3001",
   router: {
-    "/api": "http://localhost:3002",
-    "/admin-static": "http://localhost:3002",
-    "/admin": "http://localhost:3002/api/v1",
-    "/socket.io": "http://localhost:3002",
+    "/api": "http://server:3002",
+    "/admin-static": "http://server:3002",
+    "/admin": "http://server:3002/api/v1",
+    "/socket.io": "http://server:3002",
   },
   ws: true,
   logLevel: "warn",

--- a/infrastructure/dev/docker-compose.yml
+++ b/infrastructure/dev/docker-compose.yml
@@ -1,10 +1,37 @@
-version: "2"
+# TODO
+# - mount source code for live reload
+# - use separate docker networks
+# - separate project out into individual container images
+# - consider moving this file to project root
+
+version: "3.9"
 
 services:
+
+  proxy:
+    build: ../../
+    command: "yarn run dev:proxy"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+      - app
+  server:
+    build: ../../
+    command: "yarn workspace @koh/server dev"
+    environment:
+      DB_URL: "postgres://postgres@postgresql:5432/dev"
+    depends_on:
+      - postgresql
+      - redis
+  app:
+    build: ../../
+    command: "yarn workspace @koh/app dev"
+    depends_on:
+      - server
+
   postgresql:
     image: postgres:11.5
-    ports:
-      - 5432:5432
     volumes:
       - ./docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
       - pg:/var/lib/postgresql/data
@@ -14,8 +41,6 @@ services:
       - POSTGRES_PASSWORD=
   redis:
     image: redis:alpine
-    ports:
-      - "6379:6379"
 
 volumes:
   pg:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint packages/ --ext .ts,.tsx --ignore-path .gitignore",
     "test": "yarn workspace @koh/server test",
     "typeorm": "yarn workspace @koh/server typeorm",
-    "dev": "concurrently -n \"server,app,proxy\" \"yarn workspace @koh/server dev\" \"yarn workspace @koh/app dev\" \"yarn dev:proxy\"",
+    "dev": "echo 'do not use, functionality is now managed by docker-compose. Later, please uninstall concurrentlydocke'",
     "dev:proxy": "node infrastructure/dev/devProxy.js",
     "dev:db:up": "docker-compose -p officehours -f infrastructure/dev/docker-compose.yml up -d",
     "dev:db:down": "docker-compose -f infrastructure/dev/docker-compose.yml down",

--- a/packages/server/.env.development
+++ b/packages/server/.env.development
@@ -1,11 +1,11 @@
-DB_URL=postgres://postgres@localhost:5432/dev
+DB_URL=postgres://postgres@postgresql:5432/dev
 PUBLICKEY=BICM9ljt6UzPC2HsKwlGotdrOSjva59TcwEnolgjf67P8BLN-UStYY2kvTyKDT5DpqJX0sK1z5ZyCdc98_z-AjY
 PRIVATEKEY=3134tddi2nyoxnamvbImuban4fXXgiiXia4t3SGVOBA
 EMAIL=mailto:zuck@fb.com
 TWILIOACCOUNTSID=ACREMEMBERTHEALAMO
 TWILIOAUTHTOKEN=FLYMETOTHEMOONANDLETMESINGFOREVERMORE
 TWILIOPHONENUMBER=+14204206969
-JWT_SECRET=chunguschunguschunguschunguschunguschunguschunguschunguschungus 
+JWT_SECRET=chunguschunguschunguschunguschunguschunguschunguschunguschungus
 DOMAIN=http://localhost:3000
 KHOURY_PRIVATE_KEY=fake
 UPLOAD_LOCATION=uploads

--- a/packages/server/src/admin/admin.module.ts
+++ b/packages/server/src/admin/admin.module.ts
@@ -20,7 +20,7 @@ import * as session from 'express-session';
 import * as connectRedis from 'connect-redis';
 import { createClient } from 'redis';
 
-const redisClient = createClient();
+const redisClient = createClient({host: 'redis', port: 6379});
 const RedisStore = connectRedis(session);
 
 // This stops redisClient from causing jest tests to hang from an open handler

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -46,7 +46,11 @@ import { SemesterModule } from 'semester/semester.module';
     ReleaseNotesModule,
     InsightsModule,
     // Only use 'pub' for publishing events, 'sub' for subscribing, and 'db' for writing to key/value store
-    RedisModule.register([{ name: 'pub' }, { name: 'sub' }, { name: 'db' }]),
+    RedisModule.register([
+      { name: 'pub', host: 'redis', port: 6379 },
+      { name: 'sub', host: 'redis', port: 6379 },
+      { name: 'db', host: 'redis', port: 6379 }
+    ]),
     HealthcheckModule,
     AlertsModule,
     SemesterModule,


### PR DESCRIPTION
# Description

Containerize the front-end (app), back-end (server), reverse-proxy (devProxy.js) for a **reproducible** development environment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

An entire lesson on `docker-compose` wouldn't have been meaningful to put in the DEVELOPING.md but here's a quickstart guide, relevant as of 71b82e107d47c316fe0904e030faf7e1d047402f

```shell
# start everything
docker compose -f infrastructure/dev/docker-compose.yml up -d

# watch logs, unified format
docker compose -f infrastructure/dev/docker-compose.yml logs -f

# what's running?
docker compose -f infrastructure/dev/docker-compose.yml ps -a

# stop and clean up
docker compose -f infrastructure/dev/docker-compose.yml down -v
```

btw you do _not_ need to install node version 14 on your host.

I do not know how to "seed" DB with data, but here's what worked for me:

- login page accessible on http://localhost:3000/login
- admin login page accessible on http://localhost:3000/admin

Typically, `docker-compose.yml` exists in the project root and the commands would be less verbose. Alternatively you could just do

```shell
cd infrastructure/dev
docker-compose up --build
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

I just want to create a draft PR stop aaaaaa these question T_T

![stressed](https://user-images.githubusercontent.com/20404439/137435103-a59a2578-21b2-4d16-9d52-beb4bfe41ee3.png)

# Notes

A fully containerized development environment is most meaningful if you can also deploy to production using containers. Convergence between dev and prod is good.

The current code-base uses `yarn` scripts and some misc JS files to manage "infrastructure." A fully containerized setup is much different. There are some small things, like using `docker-compose` to manage process startup and lifecycle instead of `yarn run` and `concurrently`. There are some large things, such as how the containerized `node` and `node_modules` cannot (at least without much effort) be integrated with your IDE for fancy hinting and completion.

In this (currently a draft) PR I demonstrate a _proof-of-concept_ where the dev environment is fully managed by `docker-compose`. If we choose to move forward with using containers for development, here are some considerations we need to make:

- configuration must be cleaned up, so we can have a "single source of truth" for the infrastructure (what services are listening on what port, with what names, how they are being run, ...)
- cannot "hard-code" URL of services (postgres, redis, more accurately we shouldn't rely on the default `localhost:NNNN` and instead allow URLs to be configurable from `process.env.DB_URL` and `process.env.REDIS_URL`
- code needs to be moved around so we have separate container images for front-end (app), back-end (server), and `devProxy.js`
- core development team must learn how to use `docker` or `podman`

@dfarooq610 request for comment.
