### PR TITLE
Add queueId to event model

### DIFF
--- a/packages/server/migration/1634498029687-queueIdUpdate.ts
+++ b/packages/server/migration/1634498029687-queueIdUpdate.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class queueIdUpdate1634498029687 implements MigrationInterface {
+  name = 'queueIdUpdate1634498029687';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "event_model" ADD "queueId" integer`);
+    await queryRunner.query(
+      `ALTER TABLE "event_model" ADD CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac" FOREIGN KEY ("queueId") REFERENCES "queue_model"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_model" DROP CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac"`,
+    );
+    await queryRunner.query(`ALTER TABLE "event_model" DROP COLUMN "queueId"`);
+  }
+}

--- a/packages/server/migration/1634564017257-queueId_setnull.ts
+++ b/packages/server/migration/1634564017257-queueId_setnull.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class queueIdSetnull1634564017257 implements MigrationInterface {
+  name = 'queueIdSetnull1634564017257';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_model" DROP CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event_model" ADD CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac" FOREIGN KEY ("queueId") REFERENCES "queue_model"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_model" DROP CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event_model" ADD CONSTRAINT "FK_bfbc6e5ef5e94a2545ef2d625ac" FOREIGN KEY ("queueId") REFERENCES "queue_model"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -254,6 +254,7 @@ export class CourseController {
         eventType: EventType.TA_CHECKED_IN,
         user,
         courseId,
+        queueId: queue.id,
       }).save();
     } catch (err) {
       console.error(
@@ -330,6 +331,7 @@ export class CourseController {
         eventType: EventType.TA_CHECKED_OUT,
         user,
         courseId,
+        queueId: queue.id,
       }).save();
     } catch (err) {
       console.error(

--- a/packages/server/src/profile/event-model.entity.ts
+++ b/packages/server/src/profile/event-model.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { CourseModel } from '../course/course.entity';
 import { UserModel } from './user.entity';
+import { QueueModel } from '../queue/queue.entity';
 
 /**
  * Represents an Event in the EventModel table, used for advanced metrics.
@@ -45,4 +46,12 @@ export class EventModel extends BaseEntity {
   @Column({ nullable: true })
   @Exclude()
   courseId: number;
+
+  @Column({ nullable: true })
+  @Exclude()
+  queueId: number;
+
+  @ManyToOne((type) => QueueModel)
+  @JoinColumn({ name: 'queueId' })
+  queue: QueueModel;
 }

--- a/packages/server/src/profile/event-model.entity.ts
+++ b/packages/server/src/profile/event-model.entity.ts
@@ -51,7 +51,7 @@ export class EventModel extends BaseEntity {
   @Exclude()
   queueId: number;
 
-  @ManyToOne((type) => QueueModel)
+  @ManyToOne((type) => QueueModel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'queueId' })
   queue: QueueModel;
 }

--- a/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.spec.ts
@@ -138,18 +138,19 @@ describe('QueueService', () => {
       const updatedQueue3 = await QueueModel.findOne(queue3.id, {
         relations: ['staffList'],
       });
-      const checkoutEvents = (
-        await EventModel.createQueryBuilder().getMany()
-      ).map((em) => em.eventType);
+      const checkoutEvents = await EventModel.createQueryBuilder().getMany();
+      const checkoutEventTypes = checkoutEvents.map((em) => em.eventType);
+      const checkoutQueueIds = checkoutEvents.map((event) => event.queueId);
 
       expect(updatedQueue1.staffList.length).toEqual(0);
       expect(updatedQueue2.staffList.length).toEqual(0);
       expect(updatedQueue3.staffList.length).toEqual(1);
-      expect(checkoutEvents).toEqual([
+      expect(checkoutEventTypes).toEqual([
         'taCheckedOutForced',
         'taCheckedOutForced',
         'taCheckedOutForced',
       ]);
+      expect(checkoutQueueIds).toEqual([queue.id, queue2.id, queue2.id]);
     });
 
     it('if no staff are present all questions with limbo status are marked as stale', async () => {

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -23,16 +23,17 @@ export class QueueCleanService {
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async cleanAllQueues(): Promise<void> {
-    const queuesWithOpenQuestions: QueueModel[] = await QueueModel.getRepository()
-      .createQueryBuilder('queue_model')
-      .leftJoinAndSelect('queue_model.questions', 'question')
-      .where('question.status IN (:...status)', {
-        status: [
-          ...Object.values(OpenQuestionStatus),
-          ...Object.values(LimboQuestionStatus),
-        ],
-      })
-      .getMany();
+    const queuesWithOpenQuestions: QueueModel[] =
+      await QueueModel.getRepository()
+        .createQueryBuilder('queue_model')
+        .leftJoinAndSelect('queue_model.questions', 'question')
+        .where('question.status IN (:...status)', {
+          status: [
+            ...Object.values(OpenQuestionStatus),
+            ...Object.values(LimboQuestionStatus),
+          ],
+        })
+        .getMany();
 
     // Clean 1 queue at a time
     await async.mapLimit(
@@ -44,9 +45,8 @@ export class QueueCleanService {
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   public async checkoutAllStaff(): Promise<void> {
-    const queuesWithCheckedInStaff: QueueModel[] = await QueueModel.getRepository().find(
-      { relations: ['staffList'] },
-    );
+    const queuesWithCheckedInStaff: QueueModel[] =
+      await QueueModel.getRepository().find({ relations: ['staffList'] });
 
     queuesWithCheckedInStaff.forEach(async (queue) => {
       if (!(await queue.areThereOfficeHoursRightNow())) {

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -23,17 +23,16 @@ export class QueueCleanService {
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async cleanAllQueues(): Promise<void> {
-    const queuesWithOpenQuestions: QueueModel[] =
-      await QueueModel.getRepository()
-        .createQueryBuilder('queue_model')
-        .leftJoinAndSelect('queue_model.questions', 'question')
-        .where('question.status IN (:...status)', {
-          status: [
-            ...Object.values(OpenQuestionStatus),
-            ...Object.values(LimboQuestionStatus),
-          ],
-        })
-        .getMany();
+    const queuesWithOpenQuestions: QueueModel[] = await QueueModel.getRepository()
+      .createQueryBuilder('queue_model')
+      .leftJoinAndSelect('queue_model.questions', 'question')
+      .where('question.status IN (:...status)', {
+        status: [
+          ...Object.values(OpenQuestionStatus),
+          ...Object.values(LimboQuestionStatus),
+        ],
+      })
+      .getMany();
 
     // Clean 1 queue at a time
     await async.mapLimit(
@@ -45,8 +44,9 @@ export class QueueCleanService {
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   public async checkoutAllStaff(): Promise<void> {
-    const queuesWithCheckedInStaff: QueueModel[] =
-      await QueueModel.getRepository().find({ relations: ['staffList'] });
+    const queuesWithCheckedInStaff: QueueModel[] = await QueueModel.getRepository().find(
+      { relations: ['staffList'] },
+    );
 
     queuesWithCheckedInStaff.forEach(async (queue) => {
       if (!(await queue.areThereOfficeHoursRightNow())) {
@@ -56,6 +56,7 @@ export class QueueCleanService {
             eventType: EventType.TA_CHECKED_OUT_FORCED,
             userId: ta.id,
             courseId: queue.courseId,
+            queueId: queue.id,
           }).save();
         });
         queue.staffList = [];

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -442,7 +442,7 @@ describe('Course Integration', () => {
         })
         .expect(200);
 
-      const checkinTimes = ((data.body as unknown) as TACheckinTimesResponse)
+      const checkinTimes = (data.body as unknown as TACheckinTimesResponse)
         .taCheckinTimes;
 
       const taName = ta.firstName + ' ' + ta.lastName;

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -120,6 +120,7 @@ describe('Course Integration', () => {
       const events = await EventModel.find();
       expect(events.length).toBe(1);
       expect(events[0].eventType).toBe(EventType.TA_CHECKED_IN);
+      expect(events[0].queueId).toBe(queue.id);
     });
 
     it("Doesn't allow student to check in", async () => {
@@ -238,6 +239,7 @@ describe('Course Integration', () => {
       const events = await EventModel.find();
       expect(events.length).toBe(1);
       expect(events[0].eventType).toBe(EventType.TA_CHECKED_OUT);
+      expect(events[0].queueId).toBe(queue.id);
     });
 
     it('tests student cant checkout from queue', async () => {
@@ -440,7 +442,7 @@ describe('Course Integration', () => {
         })
         .expect(200);
 
-      const checkinTimes = (data.body as unknown as TACheckinTimesResponse)
+      const checkinTimes = ((data.body as unknown) as TACheckinTimesResponse)
         .taCheckinTimes;
 
       const taName = ta.firstName + ' ' + ta.lastName;


### PR DESCRIPTION
# Description

This PR includes a change to add queue IDs to event models in order to have events linked to their corresponding queue. We added the `queueId` attribute to the event entity and in every instance of event creation.

Closes #714 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

**Manually:** We created some events by logging in as a TA and checking in and out of queues. We also logged in as a Professor to check in and out of both the Professor queue and the regular queue. We were able to open the db on Docker CLI and see the queueId column populated with the IDs.

![image](https://user-images.githubusercontent.com/39736810/137643783-97b72585-fa11-425f-8776-f01f18663f79.png)

**Unit Tests:**  We modified 3 existing tests in `course.integration.ts` and `queue-clean.service.ts` to check that when we create events they have the queue ID.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
