### PR TITLE
Prevent queues from opening automatically

### DIFF
--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -71,12 +71,7 @@ export class QueueModel extends BaseEntity {
   isOpen: boolean;
 
   async checkIsOpen(): Promise<boolean> {
-    if (this.staffList && this.staffList.length > 0) {
-      this.isOpen = true;
-      return true;
-    }
-
-    this.isOpen = await this.areThereOfficeHoursRightNow();
+    this.isOpen = this.staffList && this.staffList.length > 0;
     return this.isOpen;
   }
 

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -49,7 +49,18 @@ describe('Course Integration', () => {
       const now = new Date();
       const course = await CourseFactory.create();
 
-      await QueueFactory.create({
+      const userTA = await UserFactory.create({
+        firstName: 'a',
+        lastName: 'b',
+        email: 'dummyta@neu.edu',
+      });
+
+      await TACourseFactory.create({
+        user: userTA,
+        course: course,
+      });
+
+      const queue = await QueueFactory.create({
         room: "Matthias's Office",
         course: course,
         officeHours: [
@@ -66,17 +77,21 @@ describe('Course Integration', () => {
         course: course,
       });
 
-      await UserCourseFactory.create({
+      await supertest({ userId: userTA.id })
+        .post(`/courses/${queue.course.id}/ta_location/${queue.room}`)
+        .expect(201);
+
+      const userF = await UserCourseFactory.create({
         user: await UserFactory.create(),
         course: course,
       });
 
-      const response = await supertest({ userId: 1 })
+      const response = await supertest({ userId: userF.userId })
         .get(`/courses/${course.id}`)
         .expect(200);
 
       expect(response.body).toMatchObject({
-        queues: [{ id: 1 }, { id: 2 }],
+        queues: [{ id: 1 }],
       });
     });
 
@@ -440,7 +455,7 @@ describe('Course Integration', () => {
         })
         .expect(200);
 
-      const checkinTimes = (data.body as unknown as TACheckinTimesResponse)
+      const checkinTimes = ((data.body as unknown) as TACheckinTimesResponse)
         .taCheckinTimes;
 
       const taName = ta.firstName + ' ' + ta.lastName;

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -15,6 +15,7 @@ import { QuestionModule } from '../src/question/question.module';
 import {
   ClosedOfficeHourFactory,
   CourseFactory,
+  OfficeHourFactory,
   QuestionFactory,
   QuestionGroupFactory,
   QueueFactory,
@@ -35,23 +36,31 @@ describe('Question Integration', () => {
   describe('GET /questions/:id', () => {
     it('gets a question with the given id', async () => {
       const course = await CourseFactory.create();
-      const q = await QuestionFactory.create({
-        text: 'Help pls',
-        createdAt: new Date('2020-03-01T05:00:00.000Z'),
-        queue: await QueueFactory.create({
-          course: course,
-        }),
-      });
-
-      await UserCourseFactory.create({
+      const student1 = await UserCourseFactory.create({
         user: await UserFactory.create(),
         course: course,
       });
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
 
-      const response = await supertest({ userId: 99 })
+      const queue = await QueueFactory.create({
+        staffList: [ta.user],
+      });
+
+      const q = await QuestionFactory.create({
+        text: 'Help pls',
+        createdAt: new Date('2020-03-01T05:00:00.000Z'),
+        queue: queue,
+        creator: student1.user,
+      });
+
+      const response2 = await supertest({ userId: 99 })
         .get(`/questions/${q.id}`)
         .expect(200);
-      expect(response.body).toMatchSnapshot();
+
+      expect(response2.body).toMatchSnapshot();
     });
     it('fails to get a non-existent question', async () => {
       await supertest({ userId: 99 }).get(`/questions/999`).expect(404);
@@ -74,11 +83,19 @@ describe('Question Integration', () => {
 
     it('posts a new question', async () => {
       const course = await CourseFactory.create();
+      const user = await UserFactory.create();
+
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
+
       const queue = await QueueFactory.create({
         course: course,
         allowQuestions: true,
+        staffList: [ta.user],
       });
-      const user = await UserFactory.create();
+
       await StudentCourseFactory.create({ user, courseId: queue.courseId });
       expect(await QuestionModel.count({ where: { queueId: 1 } })).toEqual(0);
       const response = await supertest({ userId: user.id })
@@ -103,11 +120,16 @@ describe('Question Integration', () => {
     });
     it('ta cannot post  a new question', async () => {
       const course = await CourseFactory.create();
+      const user = await UserFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
       const queue = await QueueFactory.create({
         course: course,
         allowQuestions: true,
+        staffList: [ta.user],
       });
-      const user = await UserFactory.create();
       await TACourseFactory.create({ user, courseId: queue.courseId });
       expect(await QuestionModel.count({ where: { queueId: 1 } })).toEqual(0);
       await postQuestion(user, queue).expect(401);
@@ -125,9 +147,20 @@ describe('Question Integration', () => {
         .expect(404);
     });
     it('does not allow posting in course student is not in', async () => {
+      const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
+
       const queueImNotIn = await QueueFactory.create({
         allowQuestions: true,
+        course: course,
+        staffList: [ta.user],
       });
+
+      expect(await queueImNotIn.checkIsOpen()).toBe(true);
+
       const user = await UserFactory.create();
       await StudentCourseFactory.create({
         user,
@@ -135,6 +168,7 @@ describe('Question Integration', () => {
       });
       await postQuestion(user, queueImNotIn).expect(404);
     });
+
     it('post question fails on closed queue', async () => {
       const officeHours = await ClosedOfficeHourFactory.create();
       const course = await CourseFactory.create({
@@ -153,14 +187,23 @@ describe('Question Integration', () => {
       await supertest({ userId: user.id });
       await postQuestion(user, queue).expect(400);
     });
+
     it('post question fails with bad params', async () => {
       const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
       const queue = await QueueFactory.create({
         courseId: course.id,
         allowQuestions: true,
+        staffList: [ta.user],
       });
+
       const user = await UserFactory.create();
       await StudentCourseFactory.create({ user, courseId: queue.courseId });
+
+      expect(await queue.checkIsOpen()).toBe(true);
       await supertest({ userId: user.id })
         .post('/questions')
         .send({
@@ -172,13 +215,22 @@ describe('Question Integration', () => {
         })
         .expect(400);
     });
+
     it("can't create more than one open question at a time", async () => {
       const course = await CourseFactory.create({});
       const user = await UserFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
       const queue = await QueueFactory.create({
         allowQuestions: true,
         course: course,
+        staffList: [ta.user],
       });
+
+      expect(await queue.checkIsOpen()).toBe(true);
+
       await StudentCourseFactory.create({
         userId: user.id,
         courseId: queue.courseId,
@@ -196,13 +248,23 @@ describe('Question Integration', () => {
         ERROR_MESSAGES.questionController.createQuestion.oneQuestionAtATime,
       );
     });
+
     it('force a question when one is already open', async () => {
       const course = await CourseFactory.create({});
       const user = await UserFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
+
       const queue = await QueueFactory.create({
         allowQuestions: true,
         course: course,
+        staffList: [ta.user],
       });
+
+      expect(await queue.checkIsOpen()).toBe(true);
+
       await StudentCourseFactory.create({
         userId: user.id,
         courseId: queue.courseId,
@@ -225,8 +287,18 @@ describe('Question Integration', () => {
         courseId: queueOther.courseId,
       });
 
+      const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
       // Make them student
-      const queue = await QueueFactory.create({ allowQuestions: true });
+      const queue = await QueueFactory.create({
+        allowQuestions: true,
+        staffList: [ta.user],
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       await StudentCourseFactory.create({
         userId: user.id,
         courseId: queue.courseId,
@@ -239,8 +311,19 @@ describe('Question Integration', () => {
 
       await QueueFactory.create({});
 
+      const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
+
       // Make them student
-      const queue = await QueueFactory.create({ allowQuestions: true });
+      const queue = await QueueFactory.create({
+        staffList: [ta.user],
+        allowQuestions: true,
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       await StudentCourseFactory.create({
         userId: user.id,
         courseId: queue.courseId,
@@ -253,7 +336,16 @@ describe('Question Integration', () => {
   describe('PATCH /questions/:id', () => {
     it('as student creator, edit a question', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ courseId: course.id });
+      const ta = await TACourseFactory.create({
+        course: course,
+        user: await UserFactory.create(),
+      });
+      const queue = await QueueFactory.create({
+        staffList: [ta.user],
+        courseId: course.id,
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       const user = await UserFactory.create();
       await StudentCourseFactory.create({ user, courseId: queue.courseId });
       const q = await QuestionFactory.create({
@@ -286,7 +378,15 @@ describe('Question Integration', () => {
     });
     it('PATCH taHelped as student is not allowed', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ courseId: course.id });
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+
+      const queue = await QueueFactory.create({
+        courseId: course.id,
+        staffList: [ta],
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       const student = await UserFactory.create();
       await StudentCourseFactory.create({
         user: student,
@@ -298,9 +398,6 @@ describe('Question Integration', () => {
         creator: student,
         queue: queue,
       });
-
-      const ta = await UserFactory.create();
-      await TACourseFactory.create({ course: q.queue.course, user: ta });
 
       await supertest({ userId: q.creatorId })
         .patch(`/questions/${q.id}`)
@@ -315,7 +412,15 @@ describe('Question Integration', () => {
 
     it('PATCH status to helping as student not allowed', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ courseId: course.id });
+
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+      const queue = await QueueFactory.create({
+        courseId: course.id,
+        staffList: [ta],
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       const student = await UserFactory.create();
       await StudentCourseFactory.create({
         user: student,
@@ -337,13 +442,18 @@ describe('Question Integration', () => {
 
     it('PATCH status to helping as TA works', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ courseId: course.id });
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+      const queue = await QueueFactory.create({
+        course: course,
+        staffList: [ta],
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
+
       const question = await QuestionFactory.create({
         text: 'Help pls',
         queue: queue,
       });
-      const ta = await UserFactory.create();
-      await TACourseFactory.create({ courseId: queue.courseId, user: ta });
 
       const res = await supertest({ userId: ta.id })
         .patch(`/questions/${question.id}`)
@@ -365,9 +475,13 @@ describe('Question Integration', () => {
 
     it('PATCH status to Resolved as TA works', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ courseId: course.id });
       const ta = await UserFactory.create();
-      await TACourseFactory.create({ courseId: queue.courseId, user: ta });
+      await TACourseFactory.create({ course: course, user: ta });
+      const queue = await QueueFactory.create({
+        course: course,
+        staffList: [ta],
+      });
+      expect(await queue.checkIsOpen()).toBe(true);
 
       const q = await QuestionFactory.create({
         text: 'Help pls',
@@ -388,9 +502,16 @@ describe('Question Integration', () => {
     });
 
     it('PATCH anything other than status as TA not allowed', async () => {
-      const q = await QuestionFactory.create({ text: 'Help pls' });
+      const course = await CourseFactory.create();
       const ta = await UserFactory.create();
-      await TACourseFactory.create({ course: q.queue.course, user: ta });
+      await TACourseFactory.create({ course: course, user: ta });
+
+      const q = await QuestionFactory.create({
+        text: 'Help pls',
+        queue: await QueueFactory.create({ course: course, staffList: [ta] }),
+      });
+
+      expect(await q.queue.checkIsOpen()).toBe(true);
 
       await supertest({ userId: ta.id })
         .patch(`/questions/${q.id}`)
@@ -404,6 +525,9 @@ describe('Question Integration', () => {
       const ta = await UserFactory.create();
       await TACourseFactory.create({ course: q.queue.course, user: ta });
 
+      q.queue.staffList.push(ta);
+      expect(await q.queue.checkIsOpen()).toBe(true);
+
       const res = await supertest({ userId: ta.id })
         .patch(`/questions/${q.id}`)
         .send({
@@ -414,22 +538,28 @@ describe('Question Integration', () => {
     });
     it('PATCH question fails when you are not the question creator', async () => {
       const q = await QuestionFactory.create({ text: 'Help pls' });
+
       const student = await UserFactory.create();
       await StudentCourseFactory.create({
         course: q.queue.course,
         user: student,
       });
 
-      await supertest({ userId: student.id })
+      const res = await supertest({ userId: student.id })
         .patch(`/questions/${q.id}`)
         .send({
           text: 'bonjour',
         })
         .expect(401);
+
+      expect(res.body?.message).toBe(
+        'Logged-in user does not have edit access',
+      );
     });
     it('User not in course cannot patch a question', async () => {
       const course = await CourseFactory.create();
       const queue = await QueueFactory.create({ courseId: course.id });
+
       const user = await UserFactory.create();
       const q = await QuestionFactory.create({
         text: 'Help pls',
@@ -447,6 +577,7 @@ describe('Question Integration', () => {
     it('Tries to help more than one student', async () => {
       const course = await CourseFactory.create();
       const queue = await QueueFactory.create({ courseId: course.id });
+
       const q1 = await QuestionFactory.create({
         text: 'Help pls',
         queue: queue,
@@ -455,8 +586,11 @@ describe('Question Integration', () => {
         text: 'Help pls 2',
         queue: queue,
       });
+
       const ta = await UserFactory.create();
       await TACourseFactory.create({ courseId: queue.courseId, user: ta });
+      queue.staffList.push(ta);
+      expect(await queue.checkIsOpen()).toBe(true);
 
       await supertest({ userId: ta.id })
         .patch(`/questions/${q1.id}`)
@@ -477,6 +611,7 @@ describe('Question Integration', () => {
     it('creates a new group and marks questions as helping', async () => {
       const course = await CourseFactory.create();
       const queue = await QueueFactory.create({ course: course });
+
       const q1 = await QuestionFactory.create({ queue });
       const q2 = await QuestionFactory.create({ queue });
       const q3 = await QuestionFactory.create({ queue });
@@ -521,6 +656,7 @@ describe('Question Integration', () => {
     it('student cannot create group', async () => {
       const course = await CourseFactory.create();
       const queue = await QueueFactory.create({ course: course });
+
       const student = await UserFactory.create();
       await StudentCourseFactory.create({
         user: student,
@@ -546,6 +682,7 @@ describe('Question Integration', () => {
     it('disallows grouping questions that have groupable as false', async () => {
       const course = await CourseFactory.create();
       const queue = await QueueFactory.create({ course: course });
+
       const q1 = await QuestionFactory.create({ queue });
       const q2 = await QuestionFactory.create({ queue, groupable: false });
       const ta = await UserFactory.create();
@@ -553,6 +690,9 @@ describe('Question Integration', () => {
         courseId: queue.courseId,
         user: ta,
       });
+      queue.staffList.push(ta);
+      expect(await queue.checkIsOpen()).toBe(true);
+
       await supertest({ userId: ta.id })
         .post(`/questions/group`)
         .send({

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -55,11 +55,11 @@ describe('Question Integration', () => {
         creator: student1.user,
       });
 
-      const response2 = await supertest({ userId: 99 })
+      const response = await supertest({ userId: 99 })
         .get(`/questions/${q.id}`)
         .expect(200);
 
-      expect(response2.body).toMatchSnapshot();
+      expect(response.body).toMatchSnapshot();
     });
     it('fails to get a non-existent question', async () => {
       await supertest({ userId: 99 }).get(`/questions/999`).expect(404);

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -15,7 +15,6 @@ import { QuestionModule } from '../src/question/question.module';
 import {
   ClosedOfficeHourFactory,
   CourseFactory,
-  OfficeHourFactory,
   QuestionFactory,
   QuestionGroupFactory,
   QueueFactory,

--- a/packages/server/test/queue.integration.ts
+++ b/packages/server/test/queue.integration.ts
@@ -3,6 +3,7 @@ import { QuestionModel } from 'question/question.entity';
 import { QueueModule } from '../src/queue/queue.module';
 import {
   CourseFactory,
+  OfficeHourFactory,
   QuestionFactory,
   QueueFactory,
   StudentCourseFactory,
@@ -23,10 +24,14 @@ describe('Queue Integration', () => {
   describe('GET /queues/:id', () => {
     it('get a queue', async () => {
       const course = await CourseFactory.create();
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+
       const queue = await QueueFactory.create({
         courseId: course.id,
         course: course,
         questions: [await QuestionFactory.create()],
+        staffList: [ta],
       });
       const userCourse = await UserCourseFactory.create({
         user: await UserFactory.create(),
@@ -48,9 +53,66 @@ describe('Queue Integration', () => {
       });
     });
 
+    it('is not open when there are no TAs present (oh-agnostic)', async () => {
+      const now = new Date();
+      const queue = await QueueFactory.create({
+        officeHours: [
+          await OfficeHourFactory.create({
+            startTime: now,
+            endTime: new Date(now.valueOf() + 4500000),
+            room: "Matthias's Office",
+          }),
+        ],
+      });
+      const userCourse = await UserCourseFactory.create({
+        user: await UserFactory.create(),
+        course: queue.course,
+      });
+
+      const res = await supertest({ userId: userCourse.user.id })
+        .get(`/queues/${queue.id}`)
+        .expect(200);
+      expect(res.body).toMatchObject({
+        isOpen: false,
+      });
+    });
+
+    it('is open when there are TAs present', async () => {
+      const course = await CourseFactory.create();
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+      const now = new Date();
+      const queue = await QueueFactory.create({
+        course: course,
+        staffList: [ta],
+        officeHours: [
+          await OfficeHourFactory.create({
+            startTime: now,
+            endTime: new Date(now.valueOf() + 4500000),
+            room: "Matthias's Office",
+          }),
+        ],
+      });
+
+      const userCourse = await UserCourseFactory.create({
+        user: await UserFactory.create(),
+        course: queue.course,
+      });
+
+      const res = await supertest({ userId: userCourse.user.id })
+        .get(`/queues/${queue.id}`)
+        .expect(200);
+      expect(res.body).toMatchObject({
+        isOpen: true,
+      });
+    });
+
     it('returns 404 on non-existent course', async () => {
       const course = await CourseFactory.create();
-      const queue = await QueueFactory.create({ course });
+      const ta = await UserFactory.create();
+      await TACourseFactory.create({ course: course, user: ta });
+
+      const queue = await QueueFactory.create({ course, staffList: [ta] });
       const user = await UserFactory.create();
 
       await supertest({ userId: user.id })

--- a/packages/server/test/queue.integration.ts
+++ b/packages/server/test/queue.integration.ts
@@ -175,6 +175,7 @@ describe('Queue Integration', () => {
       const res = await supertest({ userId: userCourse.user.id })
         .get(`/queues/${queue.id}/questions`)
         .expect(200);
+
       expect(res.body).toMatchSnapshot();
       expect(res.body.queue[0].creator).not.toHaveProperty('firstName');
       expect(res.body.queue[0].creator).not.toHaveProperty('lastName');


### PR DESCRIPTION
# Description

Updates queues' open status to be only based on whether there are staff checked in or not (`QueueModel.staffList` is not empty). Function `checkIsOpen` is still async, but should resolve nearly instantly since it is returning a promise that is resolved instantly.

Side Effects: queues with no staff checked in are not present anymore -- ie invisible for both the TA and the student.  That being said, TA's still have a check-in button to get into the queue.  Professor queues are immune and still visible.

Tests that relied on the old defintion of 'open' were updated (`queue.integration.ts`, `course.integration.ts`, `question.integration.ts` ) to make sure that queue is open when applicable

Closes #729 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Using two browsers, log in as the student and the TA, and see how the queue's visibility changes based on whether TA is checked in or not.
- [ ] Automatic Tests: 2 tests in `queue.integration.ts`: first has oh in schedule, but no TA checked in (queue should be closed), and one where a TA is present (should be open).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
