### PR TITLE
Remove ical frontend stuff

### DIFF
--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { Calendar, CalendarProps, View } from "react-big-calendar";
 import styled from "styled-components";
 

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -26,6 +26,7 @@ export default function SchedulePanel({
   courseId,
   defaultView = "week",
 }: ScheduleProps): ReactElement {
+  return null; // TODO: Replace this with something other than the iCal
   const { course } = useCourse(courseId);
   const role = useRoleInCourse(courseId);
 

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -7,14 +7,16 @@ const _ScheduleCalendar = styled(Calendar)<CalendarProps>`
 `;
 
 type ScheduleProps = {
-  _courseId: number;
-  _defaultView?: View;
+  courseId: number;
+  defaultView?: View;
 };
 
 export default function SchedulePanel({
-  _courseId,
-  _defaultView = "week",
+  courseId,
+  defaultView = "week",
 }: ScheduleProps): ReactElement {
+  const _a = courseId;
+  const _d = defaultView;
   return null; // TODO: Replace this with something other than the iCal
   /**
   const { course } = useCourse(courseId);

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -27,6 +27,7 @@ export default function SchedulePanel({
   defaultView = "week",
 }: ScheduleProps): ReactElement {
   return null; // TODO: Replace this with something other than the iCal
+  /**
   const { course } = useCourse(courseId);
   const role = useRoleInCourse(courseId);
 
@@ -52,4 +53,5 @@ export default function SchedulePanel({
       {role === Role.PROFESSOR && <UpdateCalendarButton courseId={courseId} />}
     </div>
   );
+  */
 }

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -1,30 +1,19 @@
-import { Role } from "@koh/common";
-import moment from "moment";
 import React, { ReactElement } from "react";
-import {
-  Calendar,
-  CalendarProps,
-  Event,
-  momentLocalizer,
-  View,
-} from "react-big-calendar";
+import { Calendar, CalendarProps, View } from "react-big-calendar";
 import styled from "styled-components";
-import { useCourse } from "../../hooks/useCourse";
-import { useRoleInCourse } from "../../hooks/useRoleInCourse";
-import UpdateCalendarButton from "./UpdateCalendarButton";
 
-const ScheduleCalendar = styled(Calendar)<CalendarProps>`
+const _ScheduleCalendar = styled(Calendar)<CalendarProps>`
   height: 70vh;
 `;
 
 type ScheduleProps = {
-  courseId: number;
-  defaultView?: View;
+  _courseId: number;
+  _defaultView?: View;
 };
 
 export default function SchedulePanel({
-  courseId,
-  defaultView = "week",
+  _courseId,
+  _defaultView = "week",
 }: ScheduleProps): ReactElement {
   return null; // TODO: Replace this with something other than the iCal
   /**

--- a/packages/app/pages/course/[cid]/schedule.tsx
+++ b/packages/app/pages/course/[cid]/schedule.tsx
@@ -26,6 +26,7 @@ export default function Schedule(): ReactElement {
       </Head>
       <NavBar courseId={Number(cid)} />
       <ScheduleContainer>
+        {/* TODO: Currently, iCal stuff is not showing, replace this with something else */}
         <SchedulePanel courseId={Number(cid)} />
       </ScheduleContainer>
     </StandardPageContainer>

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -113,6 +113,7 @@ export default function Today(): ReactElement {
             )}
           </Col>
           <Col md={12} sm={24}>
+            {/* TODO: Currently, iCal stuff is not showing, replace this with something else */}
             <SchedulePanel courseId={Number(cid)} defaultView="day" />
           </Col>
         </Row>


### PR DESCRIPTION
# Description

Removes iCal calendars from being displayed on the today and schedule pages. The only 2 changes made are that the SchedulePanel component now returns null instead of the calendar and I wrote a TODO comment on the today page to indicate that the SchedulePanel doesn't return anything.

Closes #732 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Check if the calendars show up on the today front page and the schedule tab. There should just be empty space where they once were.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
