### PR TITLE
Add default teams msg to question grouping

### DIFF
--- a/.github/scripts/isMigrationNeeded.sh
+++ b/.github/scripts/isMigrationNeeded.sh
@@ -6,7 +6,6 @@ set -e
 SUB='No changes in database schema were found'
 {
   log=$(yarn migration:generate -n CHECK 2>&1)
-  echo "$log"
 } || {
   echo "$log"
   if [[ "$log" == *"$SUB"* ]]; then
@@ -14,6 +13,9 @@ SUB='No changes in database schema were found'
     exit 0
   fi
 }
+
+echo "$log"
+
 # Check if migration file exists
 if ls packages/server/migration/*-CHECK.ts 1> /dev/null 2>&1; then
   git fetch origin master

--- a/packages/app/components/Queue/TA/QuestionGrouping/AllQuestionsChecklist.tsx
+++ b/packages/app/components/Queue/TA/QuestionGrouping/AllQuestionsChecklist.tsx
@@ -4,6 +4,7 @@ import { Question, User } from "@koh/common";
 import { Checkbox, Tooltip } from "antd";
 import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
+import { useDefaultMessage } from "../../../../hooks/useDefaultMessage";
 import { useTAInQueueInfo } from "../../../../hooks/useTAInQueueInfo";
 import { BannerPrimaryButton } from "../../Banner";
 import { Header } from "../TAQueueDetail";
@@ -53,6 +54,8 @@ export default function AllQuestionsCheckList({
     }
   })();
 
+  const defaultMessage = useDefaultMessage();
+
   const onQuestionChecked = (q) => {
     if (!checkedQuestions.has(q.id)) {
       setCheckedQuestions(new Set(checkedQuestions.add(q.id)));
@@ -101,7 +104,7 @@ export default function AllQuestionsCheckList({
                   });
                   onStartCall();
                   window.open(
-                    `https://teams.microsoft.com/l/chat/0/0?users=${usersInLink}`
+                    `https://teams.microsoft.com/l/chat/0/0?users=${usersInLink}&message=${defaultMessage}`
                   );
                 }}
                 disabled={!canHelp || checkedQuestions.size === 0}

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -17,7 +17,7 @@ import {
 } from "@koh/common";
 import { message, Popconfirm, Tooltip } from "antd";
 import React, { ReactElement, useCallback } from "react";
-import { useProfile } from "../../../hooks/useProfile";
+import { useDefaultMessage } from "../../../hooks/useDefaultMessage";
 import { useQuestions } from "../../../hooks/useQuestions";
 import { useTAInQueueInfo } from "../../../hooks/useTAInQueueInfo";
 import {
@@ -40,7 +40,7 @@ export default function TAQueueDetailButtons({
   queueId: number;
   question: Question;
 }): ReactElement {
-  const profile = useProfile();
+  const defaultMessage = useDefaultMessage();
   const { mutateQuestions } = useQuestions(queueId);
 
   const changeStatus = useCallback(
@@ -74,9 +74,6 @@ export default function TAQueueDetailButtons({
   const helpStudent = () => {
     changeStatus(OpenQuestionStatus.Helping);
     if (question.isOnline) {
-      const defaultMessage = profile.includeDefaultMessage
-        ? profile.defaultMessage
-        : "";
       window.open(
         `https://teams.microsoft.com/l/chat/0/0?users=${question.creator.email}&message=${defaultMessage}`
       );

--- a/packages/app/hooks/useDefaultMessage.ts
+++ b/packages/app/hooks/useDefaultMessage.ts
@@ -1,0 +1,6 @@
+import { useProfile } from "./useProfile";
+
+export function useDefaultMessage() {
+  const profile = useProfile();
+  return (profile.includeDefaultMessage && profile.defaultMessage) || "";
+}

--- a/packages/server/src/course/course.entity.ts
+++ b/packages/server/src/course/course.entity.ts
@@ -33,7 +33,7 @@ export class CourseModel extends BaseEntity {
   @Column('text', { nullable: true })
   coordinator_email: string;
 
-  @Column('text', { nullable: true })
+  @Column('text', { nullable: false })
   @Exclude()
   icalURL: string;
 

--- a/packages/server/src/course/course.entity.ts
+++ b/packages/server/src/course/course.entity.ts
@@ -33,7 +33,7 @@ export class CourseModel extends BaseEntity {
   @Column('text', { nullable: true })
   coordinator_email: string;
 
-  @Column('text', { nullable: false })
+  @Column('text', { nullable: true })
   @Exclude()
   icalURL: string;
 


### PR DESCRIPTION
# Description
Adds the default teams message to Teams calls opened from a question group. 

Also tweak the logic to get the default message on the front end, so that if `includeDefaultMessage` is true but the `defaultMessage` is null, the teams call opens with no message instead of "null". I realized that this shouldn't actually happen if we do the backfill to set the defaultMessage of "hi my name is..." on everyone, but it's probably good to have the extra safety anyways. 

Closes https://github.com/sandboxnu/office-hours/issues/708

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 
- Manual test: Set a default teams message and open a question group
- Manual test: When you delete and seed data, you can get into a state where you have the default message turned on but the message itself is empty. Verify that calling someone in this state does not autofill the teams chat. 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
