### PR TITLE
enable and disable all courses within a semester

### DIFF
--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -9,8 +9,6 @@ import { EventModel, EventType } from 'profile/event-model.entity';
 import { QuestionModel } from 'question/question.entity';
 import { Between, Connection, In } from 'typeorm';
 import { UserCourseModel } from '../profile/user-course.entity';
-import { SemesterModel } from '../semester/semester.entity';
-import { CourseModel } from './course.entity';
 
 @Injectable()
 export class CourseService {
@@ -86,23 +84,6 @@ export class CourseService {
 
     return { taCheckinTimes };
   }
-
-  async setSemester(semester: SemesterModel, enable: boolean): Promise<void> {
-    const enableList = await CourseModel.find({
-      semester: semester,
-    });
-
-    enableList.map((course) => {
-      course.enabled = enable;
-    });
-
-    try {
-      await CourseModel.save(enableList);
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
   async removeUserFromCourse(userCourse: UserCourseModel): Promise<void> {
     if (!userCourse) {
       throw new HttpException(

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -9,6 +9,8 @@ import { EventModel, EventType } from 'profile/event-model.entity';
 import { QuestionModel } from 'question/question.entity';
 import { Between, Connection, In } from 'typeorm';
 import { UserCourseModel } from '../profile/user-course.entity';
+import { SemesterModel } from '../semester/semester.entity';
+import { CourseModel } from './course.entity';
 
 @Injectable()
 export class CourseService {
@@ -83,6 +85,22 @@ export class CourseService {
     }
 
     return { taCheckinTimes };
+  }
+
+  async setSemester(semester: SemesterModel, enable: boolean): Promise<void> {
+    const enableList = await CourseModel.find({
+      semester: semester,
+    });
+
+    enableList.map((course) => {
+      course.enabled = enable;
+    });
+
+    try {
+      await CourseModel.save(enableList);
+    } catch (err) {
+      console.log(err);
+    }
   }
 
   async removeUserFromCourse(userCourse: UserCourseModel): Promise<void> {

--- a/packages/server/src/semester/semester.module.ts
+++ b/packages/server/src/semester/semester.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { SemesterController } from './semester.controller';
+import { SemesterService } from './semester.service';
 import { SetSemesterCommand } from './setCourse.command';
 
 @Module({
   controllers: [SemesterController],
-  providers: [SetSemesterCommand],
+  providers: [SetSemesterCommand, SemesterService],
 })
 export class SemesterModule {}

--- a/packages/server/src/semester/semester.module.ts
+++ b/packages/server/src/semester/semester.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { SemesterController } from './semester.controller';
+import { SetSemesterCommand } from './setCourse.command';
 
 @Module({
   controllers: [SemesterController],
+  providers: [SetSemesterCommand],
 })
 export class SemesterModule {}

--- a/packages/server/src/semester/semester.service.spec.ts
+++ b/packages/server/src/semester/semester.service.spec.ts
@@ -82,7 +82,7 @@ describe('SemesterService', () => {
     it('setSemester disables courses when false ', async () => {
       const target = await getSemester('Fall', 2019);
 
-      await service.setSemester(target, false);
+      await service.toggleActiveSemester(target, false);
 
       const allCourses = await CourseModel.find({});
 
@@ -98,7 +98,7 @@ describe('SemesterService', () => {
     it('setSemester enables courses when true ', async () => {
       const target = await getSemester('Spring', 2020);
 
-      await service.setSemester(target, false);
+      await service.toggleActiveSemester(target, false);
 
       const allCourses = await CourseModel.find({
         semester: target,
@@ -107,7 +107,7 @@ describe('SemesterService', () => {
       expect(allCourses.length).toBeGreaterThan(0);
       allCourses.map((course) => expect(course.enabled).toBeFalsy());
 
-      await service.setSemester(target, true);
+      await service.toggleActiveSemester(target, true);
 
       const allCourses2 = await CourseModel.find({
         semester: target,

--- a/packages/server/src/semester/semester.service.spec.ts
+++ b/packages/server/src/semester/semester.service.spec.ts
@@ -1,0 +1,120 @@
+import { Connection } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestTypeOrmModule } from '../../test/util/testUtils';
+import { SemesterService } from './semester.service';
+import { CourseFactory, SemesterFactory } from '../../test/util/factories';
+import { CourseModel } from '../course/course.entity';
+import { Season } from '@koh/common';
+import { SemesterModel } from './semester.entity';
+
+describe('SemesterService', () => {
+  let service: SemesterService;
+  let conn: Connection;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestTypeOrmModule],
+      providers: [SemesterService],
+    }).compile();
+
+    service = module.get<SemesterService>(SemesterService);
+    conn = module.get<Connection>(Connection);
+  });
+
+  afterAll(async () => {
+    await conn.close();
+  });
+
+  beforeEach(async () => {
+    await conn.synchronize(true);
+  });
+
+  describe('setSemester', () => {
+    beforeEach(async () => {
+      await CourseFactory.create({
+        semester: await SemesterFactory.create({
+          season: 'Fall',
+          year: 2020,
+        }),
+      });
+      await CourseFactory.create({
+        semester: await SemesterFactory.create({
+          season: 'Spring',
+          year: 2020,
+        }),
+      });
+      await CourseFactory.create({
+        semester: await SemesterFactory.create({
+          season: 'Summer_Full',
+          year: 2020,
+        }),
+      });
+
+      await CourseFactory.create({
+        semester: await SemesterFactory.create({
+          season: 'Summer_1',
+          year: 2020,
+        }),
+      });
+      await CourseFactory.create({
+        semester: await SemesterFactory.create({
+          season: 'Summer_2',
+          year: 2020,
+        }),
+      });
+
+      await CourseFactory.create({
+        name: 'f2019 cs2500',
+        semester: await SemesterFactory.create({
+          season: 'Fall',
+          year: 2019,
+        }),
+      });
+    });
+
+    async function getSemester(sea: Season, year: number) {
+      return await SemesterModel.findOne({
+        season: sea,
+        year: year,
+      });
+    }
+
+    it('setSemester disables courses when false ', async () => {
+      const target = await getSemester('Fall', 2019);
+
+      await service.setSemester(target, false);
+
+      const allCourses = await CourseModel.find({});
+
+      allCourses
+        .filter((course) => course.semesterId === target.id)
+        .map((course) => expect(course.enabled).toBeFalsy());
+
+      allCourses
+        .filter((course) => course.semesterId !== target.id)
+        .map((course) => expect(course.enabled).toBeTruthy());
+    });
+
+    it('setSemester enables courses when true ', async () => {
+      const target = await getSemester('Spring', 2020);
+
+      await service.setSemester(target, false);
+
+      const allCourses = await CourseModel.find({
+        semester: target,
+      });
+
+      expect(allCourses.length).toBeGreaterThan(0);
+      allCourses.map((course) => expect(course.enabled).toBeFalsy());
+
+      await service.setSemester(target, true);
+
+      const allCourses2 = await CourseModel.find({
+        semester: target,
+      });
+      expect(allCourses.length).toBeGreaterThan(0);
+
+      allCourses2.map((course) => expect(course.enabled).toBeTruthy());
+    });
+  });
+});

--- a/packages/server/src/semester/semester.service.ts
+++ b/packages/server/src/semester/semester.service.ts
@@ -7,7 +7,10 @@ import { CourseModel } from '../course/course.entity';
 export class SemesterService {
   constructor(private connection: Connection) {}
 
-  async setSemester(semester: SemesterModel, enable: boolean): Promise<void> {
+  async toggleActiveSemester(
+    semester: SemesterModel,
+    enable: boolean,
+  ): Promise<void> {
     const enableList = await CourseModel.find({
       semester: semester,
     });

--- a/packages/server/src/semester/semester.service.ts
+++ b/packages/server/src/semester/semester.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { Connection } from 'typeorm';
+import { SemesterModel } from './semester.entity';
+import { CourseModel } from '../course/course.entity';
+
+@Injectable()
+export class SemesterService {
+  constructor(private connection: Connection) {}
+
+  async setSemester(semester: SemesterModel, enable: boolean): Promise<void> {
+    const enableList = await CourseModel.find({
+      semester: semester,
+    });
+
+    enableList.map((course) => {
+      course.enabled = enable;
+    });
+
+    try {
+      await CourseModel.save(enableList);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+}

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -1,8 +1,8 @@
 import { Command, Positional } from 'nestjs-command';
 import { Injectable } from '@nestjs/common';
-import { SemesterFactory } from '../../test/util/factories';
 import { Season } from '@koh/common';
 import { SemesterService } from './semester.service';
+import { SemesterModel } from './semester.entity';
 
 @Injectable()
 export class SetSemesterCommand {
@@ -67,12 +67,14 @@ export class SetSemesterCommand {
         return;
     }
 
-    const targetEnable = await SemesterFactory.create({
-      season: sem,
-      year: year,
-    });
+    const targetEnable = await this.getSemester(sem, year);
+    if (!targetEnable) {
+      console.log('semester is not bound to any courses, exiting');
+      return;
+    }
 
     await this.semService.setSemester(targetEnable, enOrDisable);
+    console.log('done');
   }
 
   validateSemester(sem: string): Season {
@@ -86,5 +88,13 @@ export class SetSemesterCommand {
       default:
         return null;
     }
+  }
+
+  async getSemester(sea: Season, year: number) {
+    // we need to some id matching
+    return await SemesterModel.findOne({
+      season: sea,
+      year: year,
+    });
   }
 }

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -1,0 +1,69 @@
+import { Command, Positional } from 'nestjs-command';
+import { Injectable } from '@nestjs/common';
+import { CourseService } from '../course/course.service';
+import { SemesterFactory } from '../../test/util/factories';
+import { Season } from '@koh/common';
+
+@Injectable()
+export class SetSemesterCommand {
+  constructor(private readonly courseService: CourseService) {}
+  @Command({
+    command: 'course:modsemeter <mode> <semester> <year>',
+    describe: '',
+    autoExit: true,
+  })
+  async create(
+    @Positional({
+      name: 'mode',
+      describe: 'mode: either enable or disable.',
+      type: 'string',
+    })
+    mode: string,
+    @Positional({
+      name: 'semester',
+      describe: 'the semester to enable',
+      type: 'string',
+    })
+    semester: string,
+    @Positional({
+      name: 'year',
+      describe: 'year to enable',
+      type: 'number',
+    })
+    year: number,
+  ): Promise<void> {
+    if (!(semester as Season)) {
+      console.log('invalid season:' + semester);
+      console.log(
+        'pick from one of:' +
+          '\n"Fall"' +
+          '\n"Spring"' +
+          '\n"Summer_1"' +
+          '\n"Summer_2"' +
+          '\n"Summer_Full"',
+      );
+      return;
+    }
+
+    let enOrDisable = mode === 'enable';
+
+    switch (mode) {
+      case 'enable':
+        enOrDisable = true;
+        break;
+      case 'disable':
+        enOrDisable = false;
+        break;
+      default:
+        console.error('mode was not one of "enable" or "disable", got ' + mode);
+        return;
+    }
+
+    const targetEnable = await SemesterFactory.create({
+      season: semester as Season,
+      year: year,
+    });
+
+    await this.courseService.setSemester(targetEnable, enOrDisable);
+  }
+}

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -1,12 +1,12 @@
 import { Command, Positional } from 'nestjs-command';
 import { Injectable } from '@nestjs/common';
-import { CourseService } from '../course/course.service';
 import { SemesterFactory } from '../../test/util/factories';
 import { Season } from '@koh/common';
+import { SemesterService } from './semester.service';
 
 @Injectable()
 export class SetSemesterCommand {
-  constructor(private readonly courseService: CourseService) {}
+  constructor(private readonly semService: SemesterService) {}
   @Command({
     command: 'course:modsemeter <mode> <semester> <year>',
     describe: '',
@@ -64,6 +64,6 @@ export class SetSemesterCommand {
       year: year,
     });
 
-    await this.courseService.setSemester(targetEnable, enOrDisable);
+    await this.semService.setSemester(targetEnable, enOrDisable);
   }
 }

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -8,8 +8,8 @@ import { SemesterModel } from './semester.entity';
 export class SetSemesterCommand {
   constructor(private readonly semService: SemesterService) {}
   @Command({
-    command: 'semester:modsemester <mode> <semester> <year>',
-    describe: '',
+    command: 'semester:toggleActiveSemester  <mode> <semester> <year>',
+    describe: '(disable or enable) all the classes in a given semester',
     autoExit: true,
   })
   async create(
@@ -51,20 +51,13 @@ export class SetSemesterCommand {
       return;
     }
 
-    let enOrDisable = mode === 'enable';
+    const isEnable = this.enableOrDisable(mode);
 
-    switch (mode) {
-      case 'enable':
-        enOrDisable = true;
-        break;
-      case 'disable':
-        enOrDisable = false;
-        break;
-      default:
-        console.error(
-          'Mode must be one of "enable" or "disable", got "' + mode + '".',
-        );
-        return;
+    if (isEnable === null) {
+      console.error(
+        'Mode must be one of "enable" or "disable", got "' + mode + '".',
+      );
+      return;
     }
 
     const targetEnable = await this.getSemester(sem, year);
@@ -73,7 +66,7 @@ export class SetSemesterCommand {
       return;
     }
 
-    await this.semService.setSemester(targetEnable, enOrDisable);
+    await this.semService.setSemester(targetEnable, isEnable);
     console.log('done');
   }
 
@@ -85,6 +78,17 @@ export class SetSemesterCommand {
       case 'Summer_2':
       case 'Summer_Full':
         return sem;
+      default:
+        return null;
+    }
+  }
+
+  enableOrDisable(mode: string): boolean {
+    switch (mode) {
+      case 'enable':
+        return true;
+      case 'disable':
+        return false;
       default:
         return null;
     }

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -8,7 +8,7 @@ import { SemesterService } from './semester.service';
 export class SetSemesterCommand {
   constructor(private readonly semService: SemesterService) {}
   @Command({
-    command: 'course:modsemeter <mode> <semester> <year>',
+    command: 'semester:modsemester <mode> <semester> <year>',
     describe: '',
     autoExit: true,
   })
@@ -32,15 +32,21 @@ export class SetSemesterCommand {
     })
     year: number,
   ): Promise<void> {
-    if (!(semester as Season)) {
-      console.log('invalid season:' + semester);
+    if (Number.isNaN(year)) {
+      console.log('Invalid year: Please provide the year as a number.');
+      return;
+    }
+
+    const sem = this.validateSemester(semester);
+    if (!sem) {
+      console.log('Invalid season: "' + semester + '"');
       console.log(
-        'pick from one of:' +
-          '\n"Fall"' +
-          '\n"Spring"' +
-          '\n"Summer_1"' +
-          '\n"Summer_2"' +
-          '\n"Summer_Full"',
+        'Pick from one of:' +
+          '\n-  "Fall"' +
+          '\n-  "Spring"' +
+          '\n-  "Summer_1"' +
+          '\n-  "Summer_2"' +
+          '\n-  "Summer_Full"',
       );
       return;
     }
@@ -55,15 +61,30 @@ export class SetSemesterCommand {
         enOrDisable = false;
         break;
       default:
-        console.error('mode was not one of "enable" or "disable", got ' + mode);
+        console.error(
+          'Mode must be one of "enable" or "disable", got "' + mode + '".',
+        );
         return;
     }
 
     const targetEnable = await SemesterFactory.create({
-      season: semester as Season,
+      season: sem,
       year: year,
     });
 
     await this.semService.setSemester(targetEnable, enOrDisable);
+  }
+
+  validateSemester(sem: string): Season {
+    switch (sem) {
+      case 'Fall':
+      case 'Spring':
+      case 'Summer_1':
+      case 'Summer_2':
+      case 'Summer_Full':
+        return sem;
+      default:
+        return null;
+    }
   }
 }

--- a/packages/server/src/semester/setCourse.command.ts
+++ b/packages/server/src/semester/setCourse.command.ts
@@ -66,7 +66,7 @@ export class SetSemesterCommand {
       return;
     }
 
-    await this.semService.setSemester(targetEnable, isEnable);
+    await this.semService.toggleActiveSemester(targetEnable, isEnable);
     console.log('done');
   }
 


### PR DESCRIPTION
# Description

Command for mass enabling and disabling courses based on the semester (for transitioning between semesters)

command is `yarn cli semester:modsemester <mode> <season> <year>`
where: 
-  `mode` is one of `enable` or `disable`, 
- `season` is one of `Fall` `Spring` `Summer_Full` `Summer_1` or `Summer_2`
- `year` is a number

this modifies the enabled field to match `mode` (`true` for enabled, false for `disabled`).

Added a semster service `semester.service.ts` and a corresponding test file `semester.service.spec.ts`  to test on different inputs.

Note: the only kind of equality between semesters is matching `semesterId`, so in order to refer to a semester, we need to perform a lookup to get the `SemesterModel` and the specific id.  This is done with `getSemester`. 


Please include a summary of the change and which issue is fixed.
Closes #768 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Tests in semester.service.spec.ts to test enabling a semester and disabling semester (make sure there are no side effects and courses enabled status' are as expected.)

- [ ] Tested manually using `yarn cli` on dev env


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
