### PR TITLE
fix: load semester during calendar parsing

### DIFF
--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -191,9 +191,10 @@ export class IcalService {
       where: { courseId: course.id, room: 'Online' },
     });
     const semester =
+      course.semester ||
       (await SemesterModel.findOne({
         where: { id: course.semesterId },
-      })) || course.semester;
+      }));
 
     if (!queue) {
       queue = await QueueModel.create({

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -190,6 +190,9 @@ export class IcalService {
     let queue = await QueueModel.findOne({
       where: { courseId: course.id, room: 'Online' },
     });
+    const semester = await SemesterModel.findOne({
+      where: { id: course.semesterId },
+    });
 
     if (!queue) {
       queue = await QueueModel.create({
@@ -201,8 +204,8 @@ export class IcalService {
       }).save();
     }
 
-    const semBegin = this.getSemBegin(course.semester);
-    const semEnd = this.getSemEnd(course.semester);
+    const semBegin = this.getSemBegin(semester);
+    const semEnd = this.getSemEnd(semester);
 
     const icalURL = await fromURL(course.icalURL);
 

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -190,9 +190,10 @@ export class IcalService {
     let queue = await QueueModel.findOne({
       where: { courseId: course.id, room: 'Online' },
     });
-    const semester = await SemesterModel.findOne({
-      where: { id: course.semesterId },
-    });
+    const semester =
+      (await SemesterModel.findOne({
+        where: { id: course.semesterId },
+      })) || course.semester;
 
     if (!queue) {
       queue = await QueueModel.create({

--- a/packages/server/src/seed/seed.controller.ts
+++ b/packages/server/src/seed/seed.controller.ts
@@ -8,6 +8,7 @@ import { EventModel, EventType } from 'profile/event-model.entity';
 import { UserCourseModel } from 'profile/user-course.entity';
 import { UserModel } from 'profile/user.entity';
 import { QuestionGroupModel } from 'question/question-group.entity';
+import { SemesterModel } from 'semester/semester.entity';
 import { Connection, getManager } from 'typeorm';
 import {
   CourseFactory,
@@ -48,6 +49,7 @@ export class SeedController {
     await this.seedService.deleteAll(UserModel);
     await this.seedService.deleteAll(CourseSectionMappingModel);
     await this.seedService.deleteAll(CourseModel);
+    await this.seedService.deleteAll(SemesterModel);
     const manager = getManager();
     manager.query('ALTER SEQUENCE user_model_id_seq RESTART WITH 1;');
 
@@ -99,8 +101,14 @@ export class SeedController {
       // But since the semester is centered in Fall 2020,
       // the events will get filtered out since they arent in that date.
       // you will need to reseed data!
-      await SemesterFactory.create({ season: 'Fall', year: 2020 });
-      await CourseFactory.create({ timezone: 'America/New_York' });
+      const semester = await SemesterFactory.create({
+        season: 'Fall',
+        year: 2020,
+      });
+      await CourseFactory.create({
+        timezone: 'America/New_York',
+        semesterId: semester.id,
+      });
     }
 
     const course = await CourseModel.findOne({


### PR DESCRIPTION
# Description
`course.semester` was nonexistent when parsing the ical, so we loaded the semester in. Also, fixed up the seeds controller for the SemesterModel so we dont have infinite semesters locally. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Imported my own Ical File (not in this PR bc it's a secret), and manually hit the endpoint to update the calendar. We replicated the error, and after making these changes, we could successfully parse the calendar. 

