### PR TITLE
Queue Create and check-in modals

### DIFF
--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -25,6 +25,7 @@ describe('Can successfully create queues', () => {
             .contains(/^Online\w*/);
 
     });
+    /*
     it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
         const roomName = "Snell 049"
         cy.visit(`/course/${this.ta.course.id}/today`);
@@ -96,4 +97,5 @@ describe('Can successfully create queues', () => {
         cy.get("[data-cy='room-title']")
             .contains(roomName);
     });
+     */
 });

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -1,7 +1,6 @@
 import {checkInTA, createAndLoginProfessor, createAndLoginTA, createQueue, taOpenOnline} from "../../utils";
 
 describe('Can successfully create queues', () => {
-    /*
     describe('Creating Queues', () => {
         beforeEach(() => {
             // Set the state
@@ -94,11 +93,11 @@ describe('Can successfully create queues', () => {
 
             // make sure it says online (will accept Online+[zero or more chars])
             cy.get("[data-cy='room-title']")
-                .contains(/^Online\w/);
+                .contains(/^Online\w*/);
 
         });
     });
-    */
+
 
     describe('verify the behavior of the queue-create form components (TA)', () => {
         beforeEach(() => {
@@ -219,7 +218,7 @@ describe('Can successfully create queues', () => {
                 .click()
                 .invoke("attr", "aria-checked")
                 .should('equal', 'false');
-            
+
             cy.get("[data-cy=\"qc-location\"]")
                 .should('be.enabled')
                 .should('have.value', ''); // better not be empty

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -27,7 +27,7 @@ describe('Can successfully create queues', () => {
     });
 
 
-    it('Creates an in-person queue via modal', function () {
+    it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
         const roomName = "Snell 049"
         cy.visit(`/course/${this.ta.course.id}/today`);
         cy.get(".ant-modal-close-x").click();
@@ -61,42 +61,7 @@ describe('Can successfully create queues', () => {
         // make sure it says online (will accept Online+[zero or more chars])
         cy.get("[data-cy='room-title']")
             .contains(roomName);
-    });
 
-    it('Other TAs can join custom in-person queues', function ()  {
-        const roomName = "Snell 049"
-        cy.visit(`/course/${this.ta.course.id}/today`);
-        cy.get(".ant-modal-close-x").click();
-
-
-        cy.get("[data-cy=\"create-queue-modal-button\"]").click();
-        cy.wait(500);
-
-        // name the other OH field
-        cy.get("[data-cy=\"qc-location\"]")
-            .should('be.visible')
-            .trigger('focus')
-            .type(roomName)
-            .wait(250);
-
-        // submit and create queue
-        cy.get("[id^=rcDialogTitle]")
-            .contains("Create a new queue")
-            .parent()
-            .parent()
-            .should('have.class', 'ant-modal-content')
-            .within(($content) => {
-                cy.get("span").contains("Create")
-                    .parent()
-                    .should('have.class', 'ant-btn-primary')
-                    .click();
-            });
-
-        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
-
-        // make sure it says online (will accept Online+[zero or more chars])
-        cy.get("[data-cy='room-title']")
-            .contains(roomName);
 
         // Person 2
         createAndLoginTA({

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -111,6 +111,7 @@ describe('Can successfully create queues', () => {
 
         cy.get("[data-cy=\"select-existing-queue\"]").click();
         cy.get(`[data-cy="select-queue-${roomName}"]`).click();
+        cy.wait(500);
 
         cy.percySnapshot("CheckIn Modal Selection Page -- Custom Already Created")
 

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -4,15 +4,15 @@ describe('Can successfully create queues', () => {
     beforeEach(() => {
         // Set the state
         createAndLoginTA();
-        createQueue({
-            courseId: "ta.course.id",
-        });
+
     });
 
 
     it('Join an online queue via modal', function () {
-
-        cy.visit(`/course/${this.queue.course.id}/today`, {timeout : 20000});
+        createQueue({
+            courseId: "ta.course.id",
+        });
+        cy.visit(`/course/${this.ta.course.id}/today`, {timeout : 20000});
         cy.get(".ant-modal-close-x").click();
         cy.wait(1000);
         // open the online queue
@@ -29,7 +29,7 @@ describe('Can successfully create queues', () => {
 
     it('Creates an in-person queue via modal', function () {
         const roomName = "Snell 049"
-        cy.visit(`/course/${this.queue.course.id}/today`);
+        cy.visit(`/course/${this.ta.course.id}/today`);
         cy.get(".ant-modal-close-x").click();
 
 
@@ -65,7 +65,7 @@ describe('Can successfully create queues', () => {
 
     it('Other TAs can join custom in-person queues', function ()  {
         const roomName = "Snell 049"
-        cy.visit(`/course/${this.queue.course.id}/today`);
+        cy.visit(`/course/${this.ta.course.id}/today`);
         cy.get(".ant-modal-close-x").click();
 
 

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -7,25 +7,6 @@ describe('Can successfully create queues', () => {
 
     });
 
-
-    it('Join an online queue via modal', function () {
-        createQueue({
-            courseId: "ta.course.id",
-        });
-        cy.visit(`/course/${this.ta.course.id}/today`, {timeout : 20000});
-        cy.get(".ant-modal-close-x").click();
-        cy.wait(1000);
-        // open the online queue
-        taOpenOnline();
-
-        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
-
-        // make sure it says online (will accept Online+[zero or more chars])
-        cy.get("[data-cy='room-title']")
-            .contains(/^Online\w*/);
-
-    });
-    /*
     it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
         const roomName = "Snell 049"
         cy.visit(`/course/${this.ta.course.id}/today`);
@@ -97,5 +78,22 @@ describe('Can successfully create queues', () => {
         cy.get("[data-cy='room-title']")
             .contains(roomName);
     });
-     */
+    
+    it('Join an online queue via modal', function () {
+        createQueue({
+            courseId: "ta.course.id",
+        });
+        cy.visit(`/course/${this.ta.course.id}/today`, {timeout : 20000});
+        cy.get(".ant-modal-close-x").click();
+        cy.wait(1000);
+        // open the online queue
+        taOpenOnline();
+
+        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
+
+        // make sure it says online (will accept Online+[zero or more chars])
+        cy.get("[data-cy='room-title']")
+            .contains(/^Online\w*/);
+
+    });
 });

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -25,8 +25,6 @@ describe('Can successfully create queues', () => {
             .contains(/^Online\w*/);
 
     });
-
-
     it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
         const roomName = "Snell 049"
         cy.visit(`/course/${this.ta.course.id}/today`);

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -10,7 +10,7 @@ describe('Can successfully create queues', () => {
     });
 
 
-    it('Creates an online queue via modal', function () {
+    it('Join an online queue via modal', function () {
 
         cy.visit(`/course/${this.queue.course.id}/today`, {timeout : 20000});
         cy.get(".ant-modal-close-x").click();
@@ -33,14 +33,11 @@ describe('Can successfully create queues', () => {
         cy.get(".ant-modal-close-x").click();
 
 
-        cy.get("[data-cy='check-in-modal-button']").click();
+        cy.get("[data-cy=\"create-queue-modal-button\"]").click();
         cy.wait(500);
-        // select other
-        cy.get("span")
-            .contains("Other...")
-            .click()
+
         // name the other OH field
-        cy.get("[id=officeHourName]")
+        cy.get("[data-cy=\"qc-location\"]")
             .should('be.visible')
             .trigger('focus')
             .type(roomName)
@@ -48,12 +45,12 @@ describe('Can successfully create queues', () => {
 
         // submit and create queue
         cy.get("[id^=rcDialogTitle]")
-            .contains("Check-In To Office Hours")
+            .contains("Create a new queue")
             .parent()
             .parent()
             .should('have.class', 'ant-modal-content')
             .within(($content) => {
-                cy.get("span").contains("Check In")
+                cy.get("span").contains("Create")
                     .parent()
                     .should('have.class', 'ant-btn-primary')
                     .click();
@@ -68,18 +65,15 @@ describe('Can successfully create queues', () => {
 
     it('Other TAs can join custom in-person queues', function ()  {
         const roomName = "Snell 049"
-
         cy.visit(`/course/${this.queue.course.id}/today`);
         cy.get(".ant-modal-close-x").click();
 
-        cy.get("[data-cy='check-in-modal-button']").click();
+
+        cy.get("[data-cy=\"create-queue-modal-button\"]").click();
         cy.wait(500);
-        // select other
-        cy.get("span")
-            .contains("Other...")
-            .click()
+
         // name the other OH field
-        cy.get("[id=officeHourName]")
+        cy.get("[data-cy=\"qc-location\"]")
             .should('be.visible')
             .trigger('focus')
             .type(roomName)
@@ -87,12 +81,12 @@ describe('Can successfully create queues', () => {
 
         // submit and create queue
         cy.get("[id^=rcDialogTitle]")
-            .contains("Check-In To Office Hours")
+            .contains("Create a new queue")
             .parent()
             .parent()
             .should('have.class', 'ant-modal-content')
             .within(($content) => {
-                cy.get("span").contains("Check In")
+                cy.get("span").contains("Create")
                     .parent()
                     .should('have.class', 'ant-btn-primary')
                     .click();
@@ -114,14 +108,14 @@ describe('Can successfully create queues', () => {
 
         cy.get("[data-cy='check-in-modal-button']").click();
         cy.wait(500);
-        cy.get("span")
-            .contains(roomName)
-            .click();
+
+        cy.get("[data-cy=\"select-existing-queue\"]").click();
+        cy.get(`[data-cy="select-queue-${roomName}"]`).click();
 
         cy.percySnapshot("CheckIn Modal Selection Page -- Custom Already Created")
 
         cy.get("[id^=rcDialogTitle]")
-            .contains("Check-In To Office Hours")
+            .contains("Check into an existing queue")
             .parent()
             .parent()
             .should('have.class', 'ant-modal-content')

--- a/cypress/integration/ta/queue_create_inperson_or_online.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.js
@@ -1,99 +1,215 @@
-import {checkInTA, createAndLoginTA, createQueue, taOpenOnline} from "../../utils";
+import {checkInTA, createAndLoginProfessor, createAndLoginTA, createQueue, taOpenOnline} from "../../utils";
 
 describe('Can successfully create queues', () => {
-    beforeEach(() => {
-        // Set the state
-        createAndLoginTA();
+    describe('Creating Queues', () => {
+        beforeEach(() => {
+            // Set the state
+            createAndLoginTA();
 
-    });
+        });
+        it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
+            const roomName = "Snell 049"
+            cy.visit(`/course/${this.ta.course.id}/today`);
+            cy.get(".ant-modal-close-x").click();
 
-    it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
-        const roomName = "Snell 049"
-        cy.visit(`/course/${this.ta.course.id}/today`);
-        cy.get(".ant-modal-close-x").click();
+
+            cy.get("[data-cy=\"create-queue-modal-button\"]").click();
+            cy.wait(500);
+
+            // name the other OH field
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('be.visible')
+                .trigger('focus')
+                .type(roomName)
+                .wait(250);
+
+            // submit and create queue
+            cy.get("[id^=rcDialogTitle]")
+                .contains("Create a new queue")
+                .parent()
+                .parent()
+                .should('have.class', 'ant-modal-content')
+                .within(($content) => {
+                    cy.get("span").contains("Create")
+                        .parent()
+                        .should('have.class', 'ant-btn-primary')
+                        .click();
+                });
+
+            cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
+
+            // make sure it says online (will accept Online+[zero or more chars])
+            cy.get("[data-cy='room-title']")
+                .contains(roomName);
 
 
-        cy.get("[data-cy=\"create-queue-modal-button\"]").click();
-        cy.wait(500);
-
-        // name the other OH field
-        cy.get("[data-cy=\"qc-location\"]")
-            .should('be.visible')
-            .trigger('focus')
-            .type(roomName)
-            .wait(250);
-
-        // submit and create queue
-        cy.get("[id^=rcDialogTitle]")
-            .contains("Create a new queue")
-            .parent()
-            .parent()
-            .should('have.class', 'ant-modal-content')
-            .within(($content) => {
-                cy.get("span").contains("Create")
-                    .parent()
-                    .should('have.class', 'ant-btn-primary')
-                    .click();
+            // Person 2
+            createAndLoginTA({
+                identifier: "ta2",
+                courseId: "ta.course.id",
             });
 
-        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
 
-        // make sure it says online (will accept Online+[zero or more chars])
-        cy.get("[data-cy='room-title']")
-            .contains(roomName);
+            cy.get("[data-cy='check-in-modal-button']").click();
+            cy.wait(500);
 
+            cy.get("[data-cy=\"select-existing-queue\"]").click();
+            cy.get(`[data-cy="select-queue-${roomName}"]`).click();
+            cy.wait(500);
 
-        // Person 2
-        createAndLoginTA({
-            identifier: "ta2",
-            courseId: "ta.course.id",
+            cy.percySnapshot("CheckIn Modal Selection Page -- Custom Already Created")
+
+            cy.get("[id^=rcDialogTitle]")
+                .contains("Check into an existing queue")
+                .parent()
+                .parent()
+                .should('have.class', 'ant-modal-content')
+                .within(($content) => {
+                    cy.get("span").contains("Check In")
+                        .parent()
+                        .should('have.class', 'ant-btn-primary')
+                        .click();
+                });
+
+            cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
+
+            // make sure it says our room name (success!, p2 logged in)
+            cy.get("[data-cy='room-title']")
+                .contains(roomName);
         });
 
 
-
-        cy.get("[data-cy='check-in-modal-button']").click();
-        cy.wait(500);
-
-        cy.get("[data-cy=\"select-existing-queue\"]").click();
-        cy.get(`[data-cy="select-queue-${roomName}"]`).click();
-        cy.wait(500);
-
-        cy.percySnapshot("CheckIn Modal Selection Page -- Custom Already Created")
-
-        cy.get("[id^=rcDialogTitle]")
-            .contains("Check into an existing queue")
-            .parent()
-            .parent()
-            .should('have.class', 'ant-modal-content')
-            .within(($content) => {
-                cy.get("span").contains("Check In")
-                    .parent()
-                    .should('have.class', 'ant-btn-primary')
-                    .click();
+        it('Join an online queue via modal', function () {
+            createQueue({
+                courseId: "ta.course.id",
             });
+            cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
+            cy.get(".ant-modal-close-x").click();
+            cy.wait(1000);
+            // open the online queue
+            taOpenOnline();
 
-        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
+            cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
 
-        // make sure it says our room name (success!, p2 logged in)
-        cy.get("[data-cy='room-title']")
-            .contains(roomName);
-    });
-    
-    it('Join an online queue via modal', function () {
-        createQueue({
-            courseId: "ta.course.id",
+            // make sure it says online (will accept Online+[zero or more chars])
+            cy.get("[data-cy='room-title']")
+                .contains(/^Online\w*/);
+
         });
-        cy.visit(`/course/${this.ta.course.id}/today`, {timeout : 20000});
-        cy.get(".ant-modal-close-x").click();
-        cy.wait(1000);
-        // open the online queue
-        taOpenOnline();
+    });
 
-        cy.location("pathname", {timeout: 30000}).should("contain", "/queue");
 
-        // make sure it says online (will accept Online+[zero or more chars])
-        cy.get("[data-cy='room-title']")
-            .contains(/^Online\w*/);
+    describe('verify the behavior of the queue-create form components (TA)', () => {
+        beforeEach(() => {
+            createAndLoginTA();
+        });
 
+        it('Checks properties of the TA queue-create', function () {
+            cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
+            cy.get(".ant-modal-close-x").click();
+            cy.get("[data-cy=\"create-queue-modal-button\"]")
+                .should("be.visible")
+                .should("not.be.disabled")
+                .click();
+            cy.get("[id^=rcDialogTitle]")
+                .should("contain","Create a new queue");
+
+            // assert the allow TA's checkbox does not exist
+            cy.get("[data-cy=\"qc-allowTA\"]").should("not.exist");
+
+            // isonline should not be checked
+            cy.get("[data-cy=\"qc-isonline\"]")
+                .should("not.be.checked");
+
+            // location should be not disabled yet (editable)
+            cy.get("[data-cy=\"qc-location\"]")
+                .should("not.be.disabled")
+                .trigger('focus')
+                .type('Snell 049');
+
+            cy.get("[data-cy=\"qc-isonline\"]").check();
+
+            // TA online queues must be 'Online'
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('be.disabled')
+                .should('have.value','Online');
+
+            cy.get("[data-cy=\"qc-isonline\"]").uncheck();
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('not.be.disabled')
+                .should('have.value','');
+
+            // try to submit an empty room name:
+            cy.get("[id^=rcDialogTitle]")
+                .contains("Create a new queue")
+                .parent()
+                .parent()
+                .should('have.class', 'ant-modal-content')
+                .within(($content) => {
+                    cy.get("span").contains("Create")
+                        .parent()
+                        .should('have.class', 'ant-btn-primary')
+                        .click();
+                });
+
+            // check for alert!
+            cy.get("div[role=\"alert\"]")
+                .should("exist")
+                .contains("Please give this room a name.");
+
+            // test end
+
+        });
+    });
+
+    describe('verify the behavior of the queue-create form components (professor)', () => {
+        beforeEach(() => {
+            createAndLoginProfessor();
+        });
+
+        it('Checks properties of the prof queue-create', function () {
+            cy.visit(`/course/${this.professor.course.id}/today`, {timeout: 20000});
+            cy.get(".ant-modal-close-x").click();
+            cy.get("[data-cy=\"create-queue-modal-button\"]")
+                .should("be.visible")
+                .should("not.be.disabled")
+                .click();
+            cy.get("[id^=rcDialogTitle]")
+                .should("contain","Create a new queue");
+
+            cy.get("[data-cy=\"qc-allowTA\"]")
+                .should("exist")
+                .should("be.checked");
+
+            cy.get("[data-cy=\"qc-isonline\"]")
+                .should("exist")
+                .should("not.be.checked");
+
+            // location should be not disabled yet (editable)
+            cy.get("[data-cy=\"qc-location\"]")
+                .should("not.be.disabled")
+                .trigger('focus')
+                .type('Snell 049');
+
+            cy.get("[data-cy=\"qc-isonline\"]").check();
+
+            // location should be disabled and 'Online'
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('be.disabled')
+                .should('have.value','Online');
+
+            cy.get("[data-cy=\"qc-allowTA\"]").uncheck();
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('be.disabled')
+                .should('not.have.value','Online')
+                .should('not.have.value', ''); // better not be empty
+
+            cy.get("[data-cy=\"qc-isonline\"]").uncheck();
+            cy.get("[data-cy=\"qc-location\"]")
+                .should('be.enabled')
+                .should('have.value', ''); // better not be empty
+
+            // end of test
+        });
     });
 });

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -224,8 +224,11 @@ export const taOpenOnline = () => {
 
     cy.get("[data-cy='check-in-modal-button']").click();
     cy.wait(500);
+    cy.get("[data-cy=\"select-existing-queue\"]").click();
+    cy.get('[data-cy="select-queue-Online"]').click();
+
     cy.get("[id^=rcDialogTitle]")
-        .contains("Check-In To Office Hours")
+        .contains("Check into an existing queue")
         .parent()
         .parent()
         .should('have.class', 'ant-modal-content')

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -29,6 +29,7 @@ import {
   UpdateQuestionParams,
   UpdateQuestionResponse,
   UpdateQueueParams,
+  QueuePartial,
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -143,6 +144,18 @@ class APIClient {
       room: string
     ): Promise<TACheckoutResponse> =>
       this.req("DELETE", `/api/v1/courses/${courseId}/ta_location/${room}`),
+    makeQueue: async (
+      courseId: number,
+      room: string,
+      isProfessorQueue: boolean,
+      notes: string
+    ): Promise<TAUpdateStatusResponse> =>
+      this.req(
+        "POST",
+        `/api/v1/courses/${courseId}/generate_queue/${room}`,
+        QueuePartial,
+        { notes, isProfessorQueue }
+      ),
   };
   questions = {
     index: async (queueId: number) =>

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -1,41 +1,43 @@
 import { API } from "@koh/api-client";
 import { QueuePartial, Role } from "@koh/common";
-import { Form, Input, message, Modal, Radio } from "antd";
+import { Form, message, Modal, Select } from "antd";
 import { useRouter } from "next/router";
-import { Row } from "antd";
 import React, { ReactElement, useState } from "react";
-import styled from "styled-components";
 import { useCourse } from "../../hooks/useCourse";
 import { useProfile } from "../../hooks/useProfile";
 import { useRoleInCourse } from "../../hooks/useRoleInCourse";
 import TACheckinButton, { CheckinButton } from "./TACheckinButton";
 
-const ModalRadio = styled(Radio)`
-  display: block;
-  height: 30px;
-`;
-
 export default function TodayPageCheckinButton(): ReactElement {
   const profile = useProfile();
   const [modalVisible, setModalVisible] = useState(false);
-  const [queueToCheckInto, setQueueToCheckInto] = useState(0);
+  const [queueToCheckInto, setQueueToCheckInto] = useState(-1);
   const router = useRouter();
   const { cid } = router.query;
   const { course } = useCourse(Number(cid));
   const role = useRoleInCourse(Number(cid));
   const [form] = Form.useForm();
+  const { Option } = Select;
   const queueCheckedIn = course?.queues.find((queue) =>
     queue.staffList.find((staff) => staff.id === profile?.id)
   );
+
+  function onQueueUpdate(queueIx: number) {
+    setQueueToCheckInto(queueIx);
+  }
 
   return (
     <>
       {modalVisible && (
         <Modal
-          title="Check-In To Office Hours"
+          title="Check into an existing queue"
           visible={modalVisible}
-          onCancel={() => setModalVisible(false)}
+          onCancel={() => {
+            setModalVisible(false);
+            setQueueToCheckInto(-1);
+          }}
           okText="Check In"
+          okButtonProps={{ disabled: queueToCheckInto < 0 }}
           onOk={async () => {
             const value = await form.validateFields();
             let redirectID: QueuePartial;
@@ -60,45 +62,25 @@ export default function TodayPageCheckinButton(): ReactElement {
             }
           }}
         >
-          <h3>Which queue would you like to check into?</h3>
-          <Radio.Group
-            value={queueToCheckInto}
-            onChange={(e) => setQueueToCheckInto(e.target.value)}
+          <h3>Begin searching for a room</h3>
+          <Select
+            showSearch
+            style={{ width: 200 }}
+            placeholder="Select a course"
+            optionFilterProp="children"
+            onChange={onQueueUpdate}
+            filterOption={(input, option) => {
+              return (
+                option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+              );
+            }}
           >
             {course?.queues
               .filter((q) => (role === Role.TA ? !q.isProfessorQueue : true))
               .map((q, i) => (
-                <ModalRadio key={q.id} value={i}>
-                  {q.room}
-                </ModalRadio>
+                <Option key={i} value={i}>{`${q.room}`}</Option>
               ))}
-            <Row style={{ flexWrap: "nowrap" }}>
-              <ModalRadio value={-1}>Other...</ModalRadio>
-              {queueToCheckInto === -1 ? (
-                <Form form={form}>
-                  <Form.Item
-                    name="officeHourName"
-                    rules={[
-                      {
-                        required: true,
-                        message: "Please give this room a name.",
-                      },
-                    ]}
-                  >
-                    <Input
-                      defaultValue={
-                        role === Role.TA
-                          ? ""
-                          : `Professor ${profile.lastName}'s Office Hours`
-                      }
-                      placeholder={"Please name the room."}
-                      style={{ width: 350 }}
-                    />
-                  </Form.Item>
-                </Form>
-              ) : null}
-            </Row>
-          </Radio.Group>
+          </Select>
         </Modal>
       )}
       {!queueCheckedIn && role !== Role.STUDENT && (

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -21,9 +21,9 @@ export default function TodayPageCheckinButton(): ReactElement {
     queue.staffList.find((staff) => staff.id === profile?.id)
   );
 
-  function onQueueUpdate(queueIx: number) {
+  const onQueueUpdate = (queueIx: number) => {
     setQueueToCheckInto(queueIx);
-  }
+  };
 
   return (
     <>

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -1,6 +1,6 @@
 import { API } from "@koh/api-client";
 import { QueuePartial, Role } from "@koh/common";
-import { Form, message, Modal, Select } from "antd";
+import { message, Modal, Select } from "antd";
 import { useRouter } from "next/router";
 import React, { ReactElement, useState } from "react";
 import { useCourse } from "../../hooks/useCourse";
@@ -16,7 +16,6 @@ export default function TodayPageCheckinButton(): ReactElement {
   const { cid } = router.query;
   const { course } = useCourse(Number(cid));
   const role = useRoleInCourse(Number(cid));
-  const [form] = Form.useForm();
   const { Option } = Select;
   const queueCheckedIn = course?.queues.find((queue) =>
     queue.staffList.find((staff) => staff.id === profile?.id)
@@ -39,20 +38,13 @@ export default function TodayPageCheckinButton(): ReactElement {
           okText="Check In"
           okButtonProps={{ disabled: queueToCheckInto < 0 }}
           onOk={async () => {
-            const value = await form.validateFields();
             let redirectID: QueuePartial;
             try {
-              if (queueToCheckInto > -1) {
-                redirectID = await API.taStatus.checkIn(
-                  Number(cid),
-                  course?.queues[queueToCheckInto].room
-                );
-              } else {
-                redirectID = await API.taStatus.checkIn(
-                  Number(cid),
-                  value.officeHourName
-                );
-              }
+              // ok only enabled on nonnegative values
+              redirectID = await API.taStatus.checkIn(
+                Number(cid),
+                course?.queues[queueToCheckInto].room
+              );
               router.push(
                 "/course/[cid]/queue/[qid]",
                 `/course/${Number(cid)}/queue/${redirectID.id}`

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -14,7 +14,7 @@ export default function TodayPageCheckinButton(): ReactElement {
   const [queueToCheckInto, setQueueToCheckInto] = useState(-1);
   const router = useRouter();
   const { cid } = router.query;
-  const { course } = useCourse(Number(cid));
+  const { course, mutateCourse } = useCourse(Number(cid));
   const role = useRoleInCourse(Number(cid));
   const { Option } = Select;
   const queueCheckedIn = course?.queues.find((queue) =>
@@ -45,6 +45,7 @@ export default function TodayPageCheckinButton(): ReactElement {
                 Number(cid),
                 course?.queues[queueToCheckInto].room
               );
+              mutateCourse();
               router.push(
                 "/course/[cid]/queue/[qid]",
                 `/course/${Number(cid)}/queue/${redirectID.id}`

--- a/packages/app/components/Today/QueueCheckInButton.tsx
+++ b/packages/app/components/Today/QueueCheckInButton.tsx
@@ -61,6 +61,7 @@ export default function TodayPageCheckinButton(): ReactElement {
             placeholder="Select a course"
             optionFilterProp="children"
             onChange={onQueueUpdate}
+            data-cy="select-existing-queue"
             filterOption={(input, option) => {
               return (
                 option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
@@ -70,7 +71,11 @@ export default function TodayPageCheckinButton(): ReactElement {
             {course?.queues
               .filter((q) => (role === Role.TA ? !q.isProfessorQueue : true))
               .map((q, i) => (
-                <Option key={i} value={i}>{`${q.room}`}</Option>
+                <Option
+                  key={i}
+                  value={i}
+                  data-cy={`select-queue-${q.room}`}
+                >{`${q.room}`}</Option>
               ))}
           </Select>
         </Modal>

--- a/packages/app/components/Today/QueueCreateButton.tsx
+++ b/packages/app/components/Today/QueueCreateButton.tsx
@@ -71,7 +71,7 @@ export default function TodayPageCreateButton(): ReactElement {
                     initialValue={true}
                     valuePropName="checked"
                   >
-                    <Switch defaultChecked />
+                    <Switch data-cy="qc-isonline" defaultChecked />
                   </Form.Item>
                 </Row>
               </Col>
@@ -85,6 +85,7 @@ export default function TodayPageCreateButton(): ReactElement {
                     valuePropName="checked"
                   >
                     <Switch
+                      data-cy="qc-allowTA"
                       disabled={role === Role.TA}
                       defaultChecked={role === Role.TA}
                     />
@@ -110,7 +111,11 @@ export default function TodayPageCreateButton(): ReactElement {
                     : `Professor ${profile.lastName}'s Office Hours`
                 }
               >
-                <Input placeholder={"location"} style={{ width: 350 }} />
+                <Input
+                  data-cy="qc-location"
+                  placeholder={"location"}
+                  style={{ width: 350 }}
+                />
               </Form.Item>
             </Row>
             <Row style={{ fontWeight: "bold" }}>
@@ -118,7 +123,7 @@ export default function TodayPageCreateButton(): ReactElement {
             </Row>
             <Row>
               <Form.Item name="notes">
-                <TextArea rows={4} placeholder="Notes" />
+                <TextArea data-cy="qc-notes" rows={4} placeholder="Notes" />
               </Form.Item>
             </Row>
           </Form>

--- a/packages/app/components/Today/QueueCreateButton.tsx
+++ b/packages/app/components/Today/QueueCreateButton.tsx
@@ -1,0 +1,104 @@
+import React, { ReactElement, useState } from "react";
+import { useProfile } from "../../hooks/useProfile";
+import { Role } from "@koh/common";
+import { CheckinButton } from "./TACheckinButton";
+import { useRouter } from "next/router";
+import { useCourse } from "../../hooks/useCourse";
+import { useRoleInCourse } from "../../hooks/useRoleInCourse";
+import { Col, Form, Input, Modal, Row, Switch } from "antd";
+import TextArea from "antd/lib/input/TextArea";
+
+export default function TodayPageCreateButton(): ReactElement {
+  const profile = useProfile();
+  const router = useRouter();
+  const [modalVisible, setModalVisible] = useState(false);
+  const { cid } = router.query;
+  const { course } = useCourse(Number(cid));
+  const role = useRoleInCourse(Number(cid));
+  const queueCheckedIn = course?.queues.find((queue) =>
+    queue.staffList.find((staff) => staff.id === profile?.id)
+  );
+  const [form] = Form.useForm();
+
+  return (
+    <>
+      {modalVisible && (
+        <Modal
+          title={`Create a new queue`}
+          visible={modalVisible}
+          onCancel={() => {
+            setModalVisible(false);
+          }}
+          okText="Create"
+        >
+          <Form form={form}>
+            <Row>
+              <Col style={{ fontWeight: "bold" }}>
+                <Row>Online?</Row>
+                <Row>
+                  <Form.Item name="isOnline">
+                    <Switch defaultChecked />
+                  </Form.Item>
+                </Row>
+              </Col>
+
+              <Col style={{ fontWeight: "bold" }}>
+                <Row>Allow TAs?</Row>
+                <Row>
+                  <Form.Item name="allowTA">
+                    <Switch
+                      disabled={role === Role.TA}
+                      defaultChecked={role === Role.TA}
+                    />
+                  </Form.Item>
+                </Row>
+              </Col>
+            </Row>
+
+            <Row style={{ fontWeight: "bold" }}>Queue Location</Row>
+
+            <Row>
+              <Form.Item
+                name="officeHourName"
+                rules={[
+                  {
+                    required: true,
+                    message: "Please give this room a name.",
+                  },
+                ]}
+              >
+                <Input
+                  defaultValue={
+                    role === Role.TA
+                      ? ""
+                      : `Professor ${profile.lastName}'s Office Hours`
+                  }
+                  placeholder={"location"}
+                  style={{ width: 350 }}
+                />
+              </Form.Item>
+            </Row>
+            <Row style={{ fontWeight: "bold" }}>
+              Additional Notes (optional)
+            </Row>
+            <Row>
+              <Form.Item name="notes">
+                <TextArea rows={4} placeholder="Notes" />
+              </Form.Item>
+            </Row>
+          </Form>
+        </Modal>
+      )}
+      {!queueCheckedIn && role !== Role.STUDENT && (
+        <CheckinButton
+          type="default"
+          size="large"
+          data-cy="create-queue-modal-button"
+          onClick={() => setModalVisible(true)}
+        >
+          + Create Queue
+        </CheckinButton>
+      )}
+    </>
+  );
+}

--- a/packages/app/components/Today/QueueCreateButton.tsx
+++ b/packages/app/components/Today/QueueCreateButton.tsx
@@ -14,7 +14,7 @@ export default function TodayPageCreateButton(): ReactElement {
   const router = useRouter();
   const [modalVisible, setModalVisible] = useState(false);
   const { cid } = router.query;
-  const { course } = useCourse(Number(cid));
+  const { course, mutateCourse } = useCourse(Number(cid));
   const role = useRoleInCourse(Number(cid));
   const queueCheckedIn = course?.queues.find((queue) =>
     queue.staffList.find((staff) => staff.id === profile?.id)
@@ -39,6 +39,8 @@ export default function TodayPageCreateButton(): ReactElement {
         Number(cid),
         queueRequest.officeHourName
       );
+
+      mutateCourse();
 
       router.push(
         "/course/[cid]/queue/[qid]",

--- a/packages/app/components/Today/QueueCreateButton.tsx
+++ b/packages/app/components/Today/QueueCreateButton.tsx
@@ -17,7 +17,7 @@ export default function TodayPageCreateButton(): ReactElement {
   const { course, mutateCourse } = useCourse(Number(cid));
   const role = useRoleInCourse(Number(cid));
   const [isOnline, setIsOnline] = useState(false);
-  const [allowTA, setAllowTA] = useState(role === Role.PROFESSOR);
+  const [allowTA, setAllowTA] = useState(true);
   const queueCheckedIn = course?.queues.find((queue) =>
     queue.staffList.find((staff) => staff.id === profile?.id)
   );

--- a/packages/app/components/Today/QueueCreateButton.tsx
+++ b/packages/app/components/Today/QueueCreateButton.tsx
@@ -64,18 +64,16 @@ export default function TodayPageCreateButton(): ReactElement {
   };
 
   const updateRoomName = (online, aTA) => {
-    if (online && role === Role.PROFESSOR) {
+    if (online) {
       form.setFieldsValue({
         officeHourName: aTA
-          ? ``
+          ? `Online`
           : `Professor ${profile.lastName}'s Office Hours`,
       });
-    } else if (online && role === Role.TA) {
+    } else {
       form.setFieldsValue({
-        officeHourName: `Online`,
+        officeHourName: "",
       });
-    } else if (!online) {
-      form.setFieldsValue({ officeHourName: `` });
     }
   };
 
@@ -153,10 +151,7 @@ export default function TodayPageCreateButton(): ReactElement {
                 <Input
                   data-cy="qc-location"
                   placeholder={"Ex: ISEC 102"}
-                  disabled={
-                    isOnline &&
-                    (role === Role.TA || (role === Role.PROFESSOR && !allowTA))
-                  }
+                  disabled={isOnline}
                   style={{ width: 350 }}
                 />
               </Form.Item>

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -19,6 +19,7 @@ import ReleaseNotes from "../../../components/Today/ReleaseNotes";
 import WelcomeStudents from "../../../components/Today/WelcomeStudents";
 import { useCourse } from "../../../hooks/useCourse";
 import { useRoleInCourse } from "../../../hooks/useRoleInCourse";
+import TodayPageCreateButton from "../../../components/Today/QueueCreateButton";
 
 const Container = styled.div`
   margin-top: 32px;
@@ -113,6 +114,9 @@ export default function Today(): ReactElement {
                 )}
               />
             )*/}
+            <Row>
+              <TodayPageCreateButton />
+            </Row>
           </Col>
           <Col md={12} sm={24}>
             {/* TODO: Currently, iCal stuff is not showing, replace this with something else */}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -807,6 +807,7 @@ export const ERROR_MESSAGES = {
     updatedQueueError: "Error updating a course queue",
     queuesNotFound: "Queues not found",
     queueNotFound: "Queue not found",
+    queueAlreadyExists: "Queue already exists.",
     queueNotAuthorized: "Unable to join this professor queue as a TA",
     saveQueueError: "Unable to save queue",
     clearQueueError: "Unable to determine if queue can be cleared",

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -321,6 +321,19 @@ export class CourseController {
       );
     }
 
+    const queue = await QueueModel.findOne({
+      room,
+      courseId,
+      isDisabled: false,
+    });
+
+    if (queue) {
+      throw new HttpException(
+        ERROR_MESSAGES.courseController.queueAlreadyExists,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
     if (userCourseModel.role === Role.TA && body.isProfessorQueue) {
       throw new UnauthorizedException(
         ERROR_MESSAGES.courseController.queueNotAuthorized,

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -200,7 +200,7 @@ export class CourseController {
       );
     }
 
-    let queue = await QueueModel.findOne(
+    const queue = await QueueModel.findOne(
       {
         room,
         courseId,
@@ -223,14 +223,10 @@ export class CourseController {
         );
       }
 
-      queue = await QueueModel.create({
-        room,
-        courseId,
-        staffList: [],
-        questions: [],
-        allowQuestions: true,
-        isProfessorQueue: userCourseModel.role === Role.PROFESSOR,
-      }).save();
+      throw new HttpException(
+        ERROR_MESSAGES.courseController.queueNotFound,
+        HttpStatus.NOT_FOUND,
+      );
     }
 
     if (userCourseModel.role === Role.TA && queue.isProfessorQueue) {
@@ -330,7 +326,7 @@ export class CourseController {
     if (queue) {
       throw new HttpException(
         ERROR_MESSAGES.courseController.queueAlreadyExists,
-        HttpStatus.INTERNAL_SERVER_ERROR,
+        HttpStatus.BAD_REQUEST,
       );
     }
 

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -162,6 +162,42 @@ Object {
 }
 `;
 
+exports[`Course Integration POST /courses/:id/generate_queue/:room correctly propagates notes,profq,and name 1`] = `
+Object {
+  "allowQuestions": true,
+  "courseId": Any<Number>,
+  "id": Any<Number>,
+  "isDisabled": false,
+  "isProfessorQueue": false,
+  "notes": "example note 1",
+  "room": "abcd1",
+}
+`;
+
+exports[`Course Integration POST /courses/:id/generate_queue/:room correctly propagates notes,profq,and name 2`] = `
+Object {
+  "allowQuestions": true,
+  "courseId": Any<Number>,
+  "id": Any<Number>,
+  "isDisabled": false,
+  "isProfessorQueue": true,
+  "notes": "example note 7",
+  "room": "abcd2",
+}
+`;
+
+exports[`Course Integration POST /courses/:id/generate_queue/:room correctly propagates notes,profq,and name 3`] = `
+Object {
+  "allowQuestions": true,
+  "courseId": Any<Number>,
+  "id": Any<Number>,
+  "isDisabled": false,
+  "isProfessorQueue": false,
+  "notes": "ta queue",
+  "room": "abcd3",
+}
+`;
+
 exports[`Course Integration POST /courses/:id/ta_location/:room checks a TA into an existing queue 1`] = `
 Object {
   "allowQuestions": true,

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -308,47 +308,27 @@ describe('Course Integration', () => {
       expect(events.length).toBe(0);
     });
 
-    it('Allow a TA to create a new queue', async () => {
+    it('TA cannot create a new queue while checking in', async () => {
       const ta = await UserFactory.create();
       const tcf = await TACourseFactory.create({
         course: await CourseFactory.create(),
         user: ta,
       });
-      const response = await supertest({ userId: ta.id })
+      await supertest({ userId: ta.id })
         .post(`/courses/${tcf.courseId}/ta_location/WVH 404`)
-        .expect(201);
-
-      expect(response.body).toMatchObject({
-        id: 1,
-        room: 'WVH 404',
-        staffList: [{ id: ta.id }],
-      });
-
-      const events = await EventModel.find();
-      expect(events.length).toBe(1);
-      expect(events[0].eventType).toBe(EventType.TA_CHECKED_IN);
+        .expect(404);
     });
 
-    it('Allows a professor to create a new queue', async () => {
+    it('Professors cannot create a new queue while checking in', async () => {
       const professor = await UserFactory.create();
       const pcf = await UserCourseFactory.create({
         course: await CourseFactory.create(),
         user: professor,
         role: Role.PROFESSOR,
       });
-      const response = await supertest({ userId: professor.id })
+      await supertest({ userId: professor.id })
         .post(`/courses/${pcf.courseId}/ta_location/The Alamo`)
-        .expect(201);
-
-      expect(response.body).toMatchObject({
-        id: 1,
-        room: 'The Alamo',
-        staffList: [{ id: professor.id }],
-      });
-
-      const events = await EventModel.find();
-      expect(events.length).toBe(1);
-      expect(events[0].eventType).toBe(EventType.TA_CHECKED_IN);
+        .expect(404);
     });
 
     it("Doesn't allow users to check into multiple queues", async () => {
@@ -549,7 +529,7 @@ describe('Course Integration', () => {
       await supertest({ userId: ucp.user.id })
         .post(`/courses/${ucp.course.id}/generate_queue/abcd1`)
         .send({ notes: 'example note 2', isProfessorQueue: false })
-        .expect(500);
+        .expect(400);
     });
   });
 


### PR DESCRIPTION
# Description

Made to match the figma designs. Note: isOnline switch is not in use right now since there is no analagous field for queues.  Also created a new endpoint (`POST :id/generate_queue/:room`) in courses to create queues with a predefined notes, isProfessorQueue, name, and room.  Wrote tests for the new endpoint, and updated cypress tests to work with new interface.  Allow TA's is perma-on for TA's creating queues and toggleable for professors.

(need to fix some FE alignment things but functional and tested)

Demos below:

![qcc](https://user-images.githubusercontent.com/11274412/146472175-b552c449-a15a-4167-9050-d4bcb238b070.gif)
(check into a queue)


![qcr](https://user-images.githubusercontent.com/11274412/146472037-d3c3ba88-242f-41c1-8a60-d32d0af028da.gif)
(create a queue from scratch)


![queue-alreadyexists](https://user-images.githubusercontent.com/11274412/146472813-ad748e5f-c784-4e76-97c0-4d41c1098cde.gif)
(create a joinable, but already existing queue)

![queue-createprofessorexists](https://user-images.githubusercontent.com/11274412/146472843-20aa6d30-e593-450c-ad4e-3f3131c21dbd.gif)
(create a unjoin-able, but already exists professor queue)

Closes #771 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] Cypress tests in `queue_create_inperson_or_online.js` tests the flow of the modals.
- [x] new endpoint tested in `course.integration.ts`


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
