### PR TITLE
Backend endpoint for handling pending courses for profs

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -64,6 +64,7 @@ export class User {
   defaultMessage?: string;
   includeDefaultMessage!: boolean;
   courses!: UserCourse[];
+  pendingCourses?: KhouryProfCourse[];
   desktopNotifsEnabled!: boolean;
   @Type(() => DesktopNotifPartial)
   desktopNotifs!: DesktopNotifPartial[];

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -5,6 +5,7 @@ import { CourseSectionMappingModel } from 'login/course-section-mapping.entity';
 import { UserCourseModel } from 'profile/user-course.entity';
 import { UserModel } from 'profile/user.entity';
 import { Connection } from 'typeorm';
+import { ProfSectionGroupsModel } from './prof-section-groups.entity';
 
 @Injectable()
 export class LoginCourseService {
@@ -77,6 +78,14 @@ export class LoginCourseService {
           userCourses.push(previousCourse);
         }
       }
+    }
+
+    // If Prof, save the JSON data
+    if (info.courses[0] && !isKhouryCourse(info.courses[0])) {
+      await ProfSectionGroupsModel.create({
+        profId: user.id,
+        sectionGroups: info.courses,
+      }).save();
     }
 
     user.courses = userCourses;

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -20,13 +20,13 @@ export class LoginCourseService {
     });
 
     if (!user) {
-      user = UserModel.create({
+      user = await UserModel.create({
         courses: [],
         email: neuEmail,
         firstName: info.first_name,
         lastName: info.last_name,
         hideInsights: [],
-      });
+      }).save();
     }
 
     const userCourses = [];

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -35,6 +35,7 @@ import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { NotificationService } from '../notification/notification.service';
 import { User } from '../decorators/user.decorator';
 import { UserModel } from './user.entity';
+import { ProfileService } from './profile.service';
 
 @Controller('profile')
 @UseGuards(JwtAuthGuard)
@@ -42,6 +43,7 @@ export class ProfileController {
   constructor(
     private connection: Connection,
     private notifService: NotificationService,
+    private profileService: ProfileService,
   ) {}
 
   @Get()
@@ -100,11 +102,14 @@ export class ProfileController {
       );
     }
 
+    const pendingCourses = await this.profileService.getPendingCourses(user.id);
+
     return {
       ...userResponse,
       courses,
       phoneNumber: user.phoneNotif?.phoneNumber,
       desktopNotifs,
+      pendingCourses,
     };
   }
 

--- a/packages/server/src/profile/profile.module.ts
+++ b/packages/server/src/profile/profile.module.ts
@@ -3,10 +3,11 @@ import { ProfileController } from './profile.controller';
 import { NotificationModule } from '../notification/notification.module';
 import { ProfileService } from './profile.service';
 import { LoginModule } from 'login/login.module';
+import { LoginCourseService } from 'login/login-course.service';
 
 @Module({
   imports: [NotificationModule, LoginModule],
   controllers: [ProfileController],
-  providers: [ProfileService],
+  providers: [ProfileService, LoginCourseService],
 })
 export class ProfileModule {}

--- a/packages/server/src/profile/profile.module.ts
+++ b/packages/server/src/profile/profile.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ProfileController } from './profile.controller';
 import { NotificationModule } from '../notification/notification.module';
+import { ProfileService } from './profile.service';
+import { LoginModule } from 'login/login.module';
 
 @Module({
-  imports: [NotificationModule],
+  imports: [NotificationModule, LoginModule],
   controllers: [ProfileController],
+  providers: [ProfileService],
 })
 export class ProfileModule {}

--- a/packages/server/src/profile/profile.service.spec.ts
+++ b/packages/server/src/profile/profile.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestingModule, Test } from '@nestjs/testing';
-import { LoginCourseService } from 'login/login-course.service';
+import { LoginCourseService } from '../login/login-course.service';
 import { Connection } from 'typeorm';
 import {
   UserFactory,

--- a/packages/server/src/profile/profile.service.spec.ts
+++ b/packages/server/src/profile/profile.service.spec.ts
@@ -42,7 +42,7 @@ describe('ProfileService', () => {
       {
         name: 'Fundies 1',
         crns: [123, 456],
-        semester: '202110',
+        semester: '202110', // fall 2020
       },
       {
         name: 'OOD',
@@ -81,7 +81,16 @@ describe('ProfileService', () => {
       expect(resp).toBeUndefined();
     });
 
-    it('returns pending courses (sans already registered courses) for a prof', async () => {
+    it('returns pending courses (sans already registered courses) for a prof who never registered', async () => {
+      const resp = await service.getPendingCourses(prof1.id);
+      expect(resp).toEqual([prof1KhouryCourses[1]]);
+    });
+
+    it('returns pending courses (sans already registered courses) for a prof who registered last sem', async () => {
+      await LastRegistrationFactory.create({
+        prof: prof1,
+        lastRegisteredSemester: '202060',
+      }); // summer 2 of 2020
       const resp = await service.getPendingCourses(prof1.id);
       expect(resp).toEqual([prof1KhouryCourses[1]]);
     });

--- a/packages/server/src/profile/profile.service.spec.ts
+++ b/packages/server/src/profile/profile.service.spec.ts
@@ -1,0 +1,94 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import { LoginCourseService } from 'login/login-course.service';
+import { Connection } from 'typeorm';
+import {
+  UserFactory,
+  CourseFactory,
+  LastRegistrationFactory,
+  CourseSectionFactory,
+  ProfSectionGroupsFactory,
+} from '../../test/util/factories';
+import { TestTypeOrmModule, TestConfigModule } from '../../test/util/testUtils';
+import { ProfileService } from './profile.service';
+import { UserModel } from './user.entity';
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+
+  let conn: Connection;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestTypeOrmModule, TestConfigModule],
+      providers: [ProfileService, LoginCourseService],
+    }).compile();
+
+    service = module.get<ProfileService>(ProfileService);
+    conn = module.get<Connection>(Connection);
+  });
+
+  afterAll(async () => {
+    await conn.close();
+  });
+
+  beforeEach(async () => {
+    await conn.synchronize(true);
+  });
+
+  describe('getPendingCourses', () => {
+    let prof1: UserModel;
+    let prof2: UserModel;
+    const prof1KhouryCourses = [
+      {
+        name: 'Fundies 1',
+        crns: [123, 456],
+        semester: '202110',
+      },
+      {
+        name: 'OOD',
+        crns: [798],
+        semester: '202110',
+      },
+    ];
+    const prof2KhouryCourses = [
+      {
+        name: 'Fundies 1',
+        crns: [123, 456],
+        semester: '202110',
+      },
+    ];
+
+    beforeEach(async () => {
+      prof1 = await UserFactory.create();
+      prof2 = await UserFactory.create();
+      await ProfSectionGroupsFactory.create({
+        prof: prof1,
+        sectionGroups: prof1KhouryCourses,
+      });
+      await ProfSectionGroupsFactory.create({
+        prof: prof2,
+        sectionGroups: prof2KhouryCourses,
+      });
+      await LastRegistrationFactory.create({ prof: prof2 });
+      const fundies1 = await CourseFactory.create();
+      await CourseSectionFactory.create({ crn: 123, course: fundies1 });
+      await CourseSectionFactory.create({ crn: 456, course: fundies1 });
+    });
+
+    it('returns nothing for a non-professor', async () => {
+      const student = await UserFactory.create();
+      const resp = await service.getPendingCourses(student.id);
+      expect(resp).toBeUndefined();
+    });
+
+    it('returns pending courses (sans already registered courses) for a prof', async () => {
+      const resp = await service.getPendingCourses(prof1.id);
+      expect(resp).toEqual([prof1KhouryCourses[1]]);
+    });
+
+    it('returns no pending courses if a prof has already registered', async () => {
+      const resp = await service.getPendingCourses(prof2.id);
+      expect(resp).toEqual([]);
+    });
+  });
+});

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -1,0 +1,45 @@
+import { KhouryProfCourse } from '@koh/common';
+import { Injectable } from '@nestjs/common';
+import { LastRegistrationModel } from 'login/last-registration-model.entity';
+import { LoginCourseService } from 'login/login-course.service';
+import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
+import { Connection } from 'typeorm';
+
+@Injectable()
+export class ProfileService {
+  constructor(
+    private connection: Connection,
+    private loginCourseService: LoginCourseService,
+  ) {}
+
+  public async getPendingCourses(userId: number): Promise<KhouryProfCourse[]> {
+    const profCourses = await ProfSectionGroupsModel.findOne({
+      profId: userId,
+    });
+    const lastRegistered = await LastRegistrationModel.findOne({
+      profId: userId,
+    });
+
+    if (!profCourses) return; // not a professor
+
+    const profCourseSem =
+      profCourses.sectionGroups[0] && profCourses.sectionGroups[0].semester;
+
+    const pendingCourses = [];
+
+    if (lastRegistered?.lastRegisteredSemester !== profCourseSem) {
+      // current semester does not match last time prof registered, there may be pending courses
+      for (const c of profCourses.sectionGroups) {
+        if (c.crns.length !== 0) {
+          const courseCRN = c.crns[0];
+          const profCourse = await this.loginCourseService.courseCRNToCourse(
+            courseCRN,
+            c.semester,
+          );
+          if (!profCourse) pendingCourses.push(c);
+        }
+      }
+    }
+    return pendingCourses;
+  }
+}

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -14,10 +14,14 @@ export class ProfileService {
 
   public async getPendingCourses(userId: number): Promise<KhouryProfCourse[]> {
     const profCourses = await ProfSectionGroupsModel.findOne({
-      profId: userId,
+      where: {
+        profId: userId,
+      },
     });
     const lastRegistered = await LastRegistrationModel.findOne({
-      profId: userId,
+      where: {
+        profId: userId,
+      },
     });
 
     if (!profCourses) return; // not a professor

--- a/packages/server/test/login.integration.ts
+++ b/packages/server/test/login.integration.ts
@@ -82,7 +82,7 @@ describe('Login Integration', () => {
 
       // And that the redirect is correct
       expect(res.body).toEqual({
-        redirect: 'http://localhost:3000/api/v1/login/entry?token={"userId":1}',
+        redirect: `http://localhost:3000/api/v1/login/entry?token={"userId":${newUser.id}}`,
       });
     });
 

--- a/packages/server/test/login.integration.ts
+++ b/packages/server/test/login.integration.ts
@@ -3,11 +3,13 @@ import { JwtService } from '@nestjs/jwt';
 import { TestingModuleBuilder } from '@nestjs/testing';
 import { CourseModel } from 'course/course.entity';
 import { UserCourseModel } from 'profile/user-course.entity';
+import { SemesterModel } from 'semester/semester.entity';
 import { LoginModule } from '../src/login/login.module';
 import { UserModel } from '../src/profile/user.entity';
 import {
   CourseFactory,
   CourseSectionFactory,
+  SemesterFactory,
   UserCourseFactory,
   UserFactory,
 } from './util/factories';
@@ -119,8 +121,10 @@ describe('Login Integration', () => {
       let course3;
       beforeEach(async () => {
         // Make course mapping so usercourse can be added
+        const semester = await SemesterFactory.create();
         course = await CourseFactory.create({
           name: 'CS 2510 Accelerated',
+          semester,
         });
         await CourseSectionFactory.create({
           crn: 23456,
@@ -128,6 +132,7 @@ describe('Login Integration', () => {
         });
         course2 = await CourseFactory.create({
           name: 'CS 2510',
+          semester,
         });
         await CourseSectionFactory.create({
           crn: 34567,
@@ -135,6 +140,7 @@ describe('Login Integration', () => {
         });
         course3 = await CourseFactory.create({
           name: 'CS 2500',
+          semester,
         });
         await CourseSectionFactory.create({
           crn: 45678,
@@ -343,6 +349,43 @@ describe('Login Integration', () => {
 
         const totalUserCoursesUpdated = await UserCourseModel.count();
         expect(totalUserCoursesUpdated).toEqual(3);
+      });
+
+      it('handles new semester with unregistered courses', async () => {
+        const sem = await SemesterModel.findOne({
+          where: { season: 'Fall', year: 2022 },
+        });
+        expect(sem).toBeUndefined();
+
+        await supertest()
+          .post('/khoury_login')
+          .send({
+            email: 'liu.i@northeastern.edu',
+            campus: 1,
+            first_name: 'Iris',
+            last_name: 'Liu',
+            photo_url: 'sdf',
+            courses: [
+              {
+                crns: [23456],
+                semester: '202310', // 2022 fall
+                name: 'Fundies 2 Accel',
+              },
+            ],
+          })
+          .expect(201);
+
+        const prof = await UserModel.findOne({
+          where: { email: 'liu.i@northeastern.edu' },
+          relations: ['courses'],
+        });
+
+        expect(prof.courses).toHaveLength(0); // Does not create user courses
+
+        const newSem = await SemesterModel.findOne({
+          where: { season: 'Fall', year: 2022 },
+        });
+        expect(newSem).toBeDefined();
       });
     });
 

--- a/packages/server/test/profile.integration.ts
+++ b/packages/server/test/profile.integration.ts
@@ -2,6 +2,9 @@ import {
   StudentCourseFactory,
   UserFactory,
   CourseFactory,
+  ProfSectionGroupsFactory,
+  CourseSectionFactory,
+  LastRegistrationFactory,
 } from './util/factories';
 import { setupIntegrationTest } from './util/testUtils';
 import { ProfileModule } from '../src/profile/profile.module';
@@ -74,6 +77,45 @@ describe('Profile Integration', () => {
     it('returns 401 when not logged in', async () => {
       await UserFactory.create();
       await supertest().get('/profile').expect(401);
+    });
+
+    it('returns pending courses when they exist', async () => {
+      const prof1KhouryCourses = [
+        {
+          name: 'Fundies 1',
+          crns: [123, 456],
+          semester: '202110',
+        },
+        {
+          name: 'OOD',
+          crns: [798],
+          semester: '202110',
+        },
+      ];
+      const prof1 = await UserFactory.create();
+      await ProfSectionGroupsFactory.create({
+        prof: prof1,
+        sectionGroups: prof1KhouryCourses,
+      });
+      await LastRegistrationFactory.create({
+        prof: prof1,
+        lastRegisteredSemester: '202010',
+      });
+      const fundies1 = await CourseFactory.create();
+      await CourseSectionFactory.create({ crn: 123, course: fundies1 });
+      await CourseSectionFactory.create({ crn: 456, course: fundies1 });
+
+      const res = await supertest({ userId: prof1.id })
+        .get('/profile')
+        .expect(200);
+
+      expect(res.body.pendingCourses).toEqual([
+        {
+          name: 'OOD',
+          crns: [798],
+          semester: '202110',
+        },
+      ]);
     });
   });
 

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -10,6 +10,8 @@ import { UserCourseModel } from '../../src/profile/user-course.entity';
 import { UserModel } from '../../src/profile/user.entity';
 import { QuestionModel } from '../../src/question/question.entity';
 import { QueueModel } from '../../src/queue/queue.entity';
+import { LastRegistrationModel } from 'login/last-registration-model.entity';
+import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
 
 export const UserFactory = new Factory(UserModel)
   .attr('email', `user@neu.edu`)
@@ -86,3 +88,11 @@ export const EventFactory = new Factory(EventModel)
   .attr('eventType', EventType.TA_CHECKED_IN)
   .assocOne('user', UserFactory)
   .assocOne('course', CourseFactory);
+
+export const LastRegistrationFactory = new Factory(LastRegistrationModel)
+  .attr('lastRegisteredSemester', '202110') // Fall 2020
+  .assocOne('prof', UserFactory);
+
+export const ProfSectionGroupsFactory = new Factory(ProfSectionGroupsModel)
+  .attr('sectionGroups', [])
+  .assocOne('prof', UserFactory);


### PR DESCRIPTION
# Description

Updates the GET/profile endpoint to return pending courses for professors if there are any. This will eventually be used in the frontend to redirect to course registration page on login.

There are also some changes to the POST/khoury_login endpoint:
* Save all the professor's sectionGroup data to DB 
* Creates the SemesterModel if none found

Closes #780 (this issue overlapped with #743 but there were some things that weren't covered)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

We added integration and unit tests in `profile.integration.ts` and `profile.service.spec.ts` respectively.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
