### PR TITLE
update QueueModel queries for isDisabled

### DIFF
--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -143,7 +143,9 @@ export function QueueInfoColumn({
   return (
     <InfoColumnContainer>
       <QueueRoomGroup>
-        <QueueTitle data-cy="room-title">{queue?.room}</QueueTitle>
+        <QueueTitle data-cy="room-title">
+          {queue?.room} {queue?.isDisabled && <b>(disabled)</b>}
+        </QueueTitle>
         {!queue.allowQuestions && (
           <Tooltip title="This queue is no longer accepting questions">
             <StopOutlined
@@ -189,8 +191,9 @@ export function QueueInfoColumn({
         <DisableQueueButton
           onClick={confirmDisable}
           data-cy="queue-disable-button"
+          disabled={queue?.isDisabled}
         >
-          Disable Queue
+          {queue?.isDisabled ? `Queue disabled` : `Disable Queue`}
         </DisableQueueButton>
       )}
     </InfoColumnContainer>

--- a/packages/app/components/Queue/Student/StudentQueue.tsx
+++ b/packages/app/components/Queue/Student/StudentQueue.tsx
@@ -267,7 +267,7 @@ export default function StudentQueue({ qid }: StudentQueueProps): ReactElement {
   );
 
   if (queue && questions) {
-    if (!queue.isOpen) {
+    if (!queue.isOpen || queue.isDisabled) {
       return <h1 style={{ marginTop: "50px" }}>The Queue is Closed!</h1>;
     }
     return (

--- a/packages/app/components/Queue/Student/StudentQueue.tsx
+++ b/packages/app/components/Queue/Student/StudentQueue.tsx
@@ -299,7 +299,7 @@ export default function StudentQueue({ qid }: StudentQueueProps): ReactElement {
                 >
                   <JoinButton
                     type="primary"
-                    disabled={!queue?.allowQuestions}
+                    disabled={!queue?.allowQuestions || queue?.isDisabled}
                     data-cy="join-queue-button"
                     onClick={async () =>
                       setShowJoinPopconfirm(!(await joinQueueOpenModal(false)))

--- a/packages/app/components/Queue/Student/StudentQueue.tsx
+++ b/packages/app/components/Queue/Student/StudentQueue.tsx
@@ -267,7 +267,7 @@ export default function StudentQueue({ qid }: StudentQueueProps): ReactElement {
   );
 
   if (queue && questions) {
-    if (!queue.isOpen || queue.isDisabled) {
+    if (!queue.isOpen) {
       return <h1 style={{ marginTop: "50px" }}>The Queue is Closed!</h1>;
     }
     return (

--- a/packages/app/components/Queue/TA/TAQueue.tsx
+++ b/packages/app/components/Queue/TA/TAQueue.tsx
@@ -142,6 +142,7 @@ export default function TAQueue({ qid, courseId }: TAQueueProps): ReactElement {
                     Help Next
                   </HelpNextButton>
                 </Tooltip>
+
                 <div style={{ marginBottom: "12px" }}>
                   <TACheckinButton
                     courseId={courseId}
@@ -149,7 +150,8 @@ export default function TAQueue({ qid, courseId }: TAQueueProps): ReactElement {
                     disabled={
                       staffCheckedIntoAnotherQueue ||
                       isHelping ||
-                      (queue.isProfessorQueue && role !== Role.PROFESSOR)
+                      (queue.isProfessorQueue && role !== Role.PROFESSOR) ||
+                      queue.isDisabled
                     }
                     state={isCheckedIn ? "CheckedIn" : "CheckedOut"}
                     block

--- a/packages/app/components/Queue/TA/TAQueue.tsx
+++ b/packages/app/components/Queue/TA/TAQueue.tsx
@@ -144,18 +144,24 @@ export default function TAQueue({ qid, courseId }: TAQueueProps): ReactElement {
                 </Tooltip>
 
                 <div style={{ marginBottom: "12px" }}>
-                  <TACheckinButton
-                    courseId={courseId}
-                    room={queue?.room}
-                    disabled={
-                      staffCheckedIntoAnotherQueue ||
-                      isHelping ||
-                      (queue.isProfessorQueue && role !== Role.PROFESSOR) ||
-                      queue.isDisabled
+                  <Tooltip
+                    title={
+                      queue.isDisabled && "Cannot check into a disabled queue!"
                     }
-                    state={isCheckedIn ? "CheckedIn" : "CheckedOut"}
-                    block
-                  />
+                  >
+                    <TACheckinButton
+                      courseId={courseId}
+                      room={queue?.room}
+                      disabled={
+                        staffCheckedIntoAnotherQueue ||
+                        isHelping ||
+                        (queue.isProfessorQueue && role !== Role.PROFESSOR) ||
+                        queue.isDisabled
+                      }
+                      state={isCheckedIn ? "CheckedIn" : "CheckedOut"}
+                      block
+                    />
+                  </Tooltip>
                 </div>
               </>
             }

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -1,5 +1,5 @@
 import { API } from "@koh/api-client";
-import { Button, Modal } from "antd";
+import { Button, message, Modal } from "antd";
 import moment from "moment";
 import { useRouter } from "next/router";
 import { ReactElement, useState } from "react";
@@ -50,12 +50,16 @@ export default function TACheckinButton({
   async function checkInTA() {
     // to see old check in in person functionality look at commit b4768bbfb0f36444c80961703bdbba01ff4a5596
     //trying to limit changes to the frontend, all queues will have the room online
-    const redirectID = await API.taStatus.checkIn(courseId, room);
+    try {
+      const redirectID = await API.taStatus.checkIn(courseId, room);
 
-    router.push(
-      "/course/[cid]/queue/[qid]",
-      `/course/${courseId}/queue/${redirectID.id}`
-    );
+      router.push(
+        "/course/[cid]/queue/[qid]",
+        `/course/${courseId}/queue/${redirectID.id}`
+      );
+    } catch (err) {
+      message.error(err.response?.data?.message);
+    }
   }
 
   const [checkoutModalInfo, setCheckoutModalInfo] = useState<{

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -173,6 +173,8 @@ export class QueuePartial {
   notes?: string;
   isOpen!: boolean;
 
+  isDisabled!: boolean;
+
   @Type(() => Date)
   startTime?: Date;
 

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -204,6 +204,7 @@ export class CourseController {
       {
         room,
         courseId,
+        isDisabled: false,
       },
       { relations: ['staffList'] },
     );
@@ -370,6 +371,7 @@ export class CourseController {
       {
         room,
         courseId,
+        isDisabled: false,
       },
       { relations: ['staffList'] },
     );

--- a/packages/server/src/course/ical.service.ts
+++ b/packages/server/src/course/ical.service.ts
@@ -188,7 +188,7 @@ export class IcalService {
     );
     console.time(`scrape course ${course.id}`);
     let queue = await QueueModel.findOne({
-      where: { courseId: course.id, room: 'Online' },
+      where: { courseId: course.id, room: 'Online', isDisabled: false },
     });
     const semester =
       course.semester ||

--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -74,7 +74,8 @@ export class QueueModel extends BaseEntity {
   isOpen: boolean;
 
   async checkIsOpen(): Promise<boolean> {
-    this.isOpen = this.staffList && this.staffList.length > 0;
+    this.isOpen =
+      this.staffList && this.staffList.length > 0 && !this.isDisabled;
     return this.isOpen;
   }
 


### PR DESCRIPTION
# Description

updated all lookups that use the `room` field as a a key to look for non-disabled queues.  Updated course controller and ical service. Grepped across server/ to look for instances of `QueueModel.find`.  Also added indicators on disabled queues to tell the user that is queue disabled.  

Checking into a disabled queue yields a 404 on POST, added a message that propagates the error.  Also disabled the disable queue button, since the queue is disabled.

![disable-safeguards](https://user-images.githubusercontent.com/11274412/147508702-9a22a29f-ff58-43fc-ac7f-768b2098a2fc.gif)


Closes #797 and #798

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Tests added to endpoint to test for location key collision.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
