### PR TITLE
[Login Flow] Register Course Endpoint

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -112,7 +112,7 @@ class APIClient {
         undefined
       ),
     registerCourse: async (params: RegisterCourseParams): Promise<void> =>
-      this.req("POST", `/api/v1/courses/register_course`, undefined, params),
+      this.req("POST", `/api/v1/courses/register_courses`, undefined, params),
     getTACheckinTimes: async (
       courseId: number,
       startDate: string,

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -111,7 +111,7 @@ class APIClient {
         `/api/v1/courses/${courseId}/withdraw_course`,
         undefined
       ),
-    registerCourse: async (params: RegisterCourseParams): Promise<void> =>
+    registerCourses: async (params: RegisterCourseParams[]): Promise<void> =>
       this.req("POST", `/api/v1/courses/register_courses`, undefined, params),
     getTACheckinTimes: async (
       courseId: number,

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -18,8 +18,8 @@ import {
   GetSelfEnrollResponse,
   ListInsightsResponse,
   ListQuestionsResponse,
+  RegisterCourseParams,
   SemesterPartial,
-  //SubmitCourseParams,
   TACheckinTimesResponse,
   TACheckoutResponse,
   TAUpdateStatusResponse,
@@ -111,10 +111,8 @@ class APIClient {
         `/api/v1/courses/${courseId}/withdraw_course`,
         undefined
       ),
-    /*
-    submitCourse: async (params: SubmitCourseParams): Promise<void> =>
-      this.req("POST", `/api/v1/courses/submit_course`, undefined, params),
-    */
+    registerCourse: async (params: RegisterCourseParams): Promise<void> =>
+      this.req("POST", `/api/v1/courses/register_course`, undefined, params),
     getTACheckinTimes: async (
       courseId: number,
       startDate: string,

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -808,6 +808,7 @@ export const ERROR_MESSAGES = {
       cannotCheckIntoMultipleQueues:
         "Cannot check into multiple queues at the same time",
     },
+    courseAlreadyRegistered: "The course was already registered",
     courseNotFound: "The course was not found",
     sectionGroupNotFound: "The section group was not found",
     courseOfficeHourError: "Unable to find a course's office hours",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -696,9 +696,6 @@ export class RegisterCourseParams {
   @IsString()
   displayName!: string;
 
-  @IsArray()
-  crns!: number[];
-
   @IsString()
   semester!: string;
 

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -696,9 +696,6 @@ export class RegisterCourseParams {
   displayName!: string;
 
   @IsString()
-  semester!: string;
-
-  @IsString()
   iCalURL!: string;
 
   @IsString()

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -808,9 +808,9 @@ export const ERROR_MESSAGES = {
       cannotCheckIntoMultipleQueues:
         "Cannot check into multiple queues at the same time",
     },
-    courseAlreadyRegistered: "The course was already registered",
+    courseAlreadyRegistered: "One or more of the courses is already registered",
     courseNotFound: "The course was not found",
-    sectionGroupNotFound: "The section group was not found",
+    sectionGroupNotFound: "One or more of the section groups was not found",
     courseOfficeHourError: "Unable to find a course's office hours",
     courseHeatMapError: "Unable to get course's cached heatmap",
     courseModelError: "Course Model not found",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -809,6 +809,7 @@ export const ERROR_MESSAGES = {
         "Cannot check into multiple queues at the same time",
     },
     courseNotFound: "The course was not found",
+    sectionGroupNotFound: "The section group was not found",
     courseOfficeHourError: "Unable to find a course's office hours",
     courseHeatMapError: "Unable to get course's cached heatmap",
     courseModelError: "Course Model not found",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -680,20 +680,20 @@ export class GetAlertsResponse {
 }
 
 /**
- * Represents the parameters for register_courses endpoint.
- * @param name - The name of the section group.
- * @param displayName - user friendly display name entered by Prof
+ * Represents the parameters for a course being registered for register_courses endpoint.
+ * @param sectionGroupName - The name of the section group.
+ * @param name - user friendly display name entered by Prof
  * @param semester - The name of the semester.
  * @param iCalURL - The URL for the iCal calendar.
- * @param coordinatorEmail - The email for the course coordinator.
+ * @param coordinator_email - The email for the course coordinator.
  * @param timezone - The timezone derived from the Campus field on the form.
  */
 export class RegisterCourseParams {
   @IsString()
-  name!: string;
+  sectionGroupName!: string;
 
   @IsString()
-  displayName!: string;
+  name!: string;
 
   @IsString()
   iCalURL!: string;
@@ -825,6 +825,8 @@ export const ERROR_MESSAGES = {
     createCourse: "Error occurred while trying to create a course",
     updateCourse: "Error occurred while trying to update a course",
     createCourseMappings: "Unable to create a course mappings",
+    updateProfLastRegistered:
+      "Unable to update professor's last registered semester",
     invalidApplyURL:
       "You are unauthorized to submit an application. Please email help@khouryofficehours.com for the correct URL.",
   },

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -679,27 +679,37 @@ export class GetAlertsResponse {
   alerts!: Alert[];
 }
 
-export class SubmitCourseParams {
-  @IsString()
-  coordinator_email!: string;
-
+/**
+ * Represents the parameters for register_course endpoint.
+ * @param name - The name of the section group.
+ * @param displayName - user friendly display name entered by Prof
+ * @param crns - The list of CRNs in the section group.
+ * @param semester - The name of the semester.
+ * @param iCalURL - The URL for the iCal calendar.
+ * @param coordinatorEmail - The email for the course coordinator.
+ * @param timezone - The timezone derived from the Campus field on the form.
+ */
+export class RegisterCourseParams {
   @IsString()
   name!: string;
 
+  @IsString()
+  displayName!: string;
+
   @IsArray()
-  sections!: number[];
+  crns!: number[];
 
   @IsString()
   semester!: string;
 
   @IsString()
+  iCalURL!: string;
+
+  @IsString()
+  coordinator_email!: string;
+
+  @IsString()
   timezone!: string;
-
-  @IsString()
-  icalURL!: string;
-
-  @IsString()
-  password!: string;
 }
 
 export class SemesterPartial {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -680,10 +680,9 @@ export class GetAlertsResponse {
 }
 
 /**
- * Represents the parameters for register_course endpoint.
+ * Represents the parameters for register_courses endpoint.
  * @param name - The name of the section group.
  * @param displayName - user friendly display name entered by Prof
- * @param crns - The list of CRNs in the section group.
  * @param semester - The name of the semester.
  * @param iCalURL - The URL for the iCal calendar.
  * @param coordinatorEmail - The email for the course coordinator.

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -3,8 +3,8 @@ import {
   GetCourseOverridesResponse,
   GetCourseResponse,
   QueuePartial,
+  RegisterCourseParams,
   Role,
-  // SubmitCourseParams,
   TACheckinTimesResponse,
   TACheckoutResponse,
   UpdateCourseOverrideBody,
@@ -47,6 +47,8 @@ import { HeatmapService } from './heatmap.service';
 import { IcalService } from './ical.service';
 import { OfficeHourModel } from './office-hour.entity';
 import moment = require('moment');
+import { SemesterModel } from 'semester/semester.entity';
+import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
 
 @Controller('courses')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -525,6 +527,35 @@ export class CourseController {
     await this.courseService.removeUserFromCourse(userCourse);
   }
 
+  @Post('register_course')
+  @UseGuards(JwtAuthGuard, CourseRolesGuard)
+  @Roles(Role.PROFESSOR)
+  async registerCourse(
+    @Body() body: RegisterCourseParams,
+    @UserId() userId: number
+  ): Promise<void> {
+    const season = body.semester.split(' ')[0];
+    const year = parseInt(body.semester.split(' ')[1]);
+
+    const semester = await SemesterModel.findOne({
+      where: { season, year },
+    });
+
+    if (!semester)
+      throw new BadRequestException(
+        ERROR_MESSAGES.courseController.noSemesterFound,
+      );
+
+    const profSectionGroups = await ProfSectionGroupsModel.findOne({
+      where: { userId },
+    });
+    // verify that professor actually teaches section group name
+    // profSectionGroups.sectionGroups.find(crns) in body.crns
+    
+    // validate section group name uniqueness
+  }
+
+  
   /* TODO: This is the old login registration form.
   @Post('submit_course')
   async submitCourse(@Body() body: SubmitCourseParams): Promise<void> {

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -587,7 +587,6 @@ export class CourseController {
           icalURL: courseParams.iCalURL,
           semesterId: semester.id,
           enabled: true,
-          pending: false,
           timezone: courseParams.timezone,
         }).save();
       } catch (err) {

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -530,11 +530,7 @@ export class CourseController {
     @Body() body: RegisterCourseParams[],
     @UserId() userId: number,
   ): Promise<void> {
-    try {
-      await this.courseService.registerCourses(body, userId);
-    } catch (err) {
-      throw err;
-    }
+    await this.courseService.registerCourses(body, userId);
   }
 
   @Get(':id/ta_check_in_times')

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -565,7 +565,7 @@ export class CourseController {
           ERROR_MESSAGES.courseController.noSemesterFound,
         );
 
-      let course = null;
+      let course;
       try {
         // create the submitted course
         course = await CourseModel.create({

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -529,7 +529,7 @@ export class CourseController {
     await this.courseService.removeUserFromCourse(userCourse);
   }
 
-  @Post('register_course')
+  @Post('register_courses')
   @UseGuards(JwtAuthGuard, CourseRolesGuard)
   @Roles(Role.PROFESSOR)
   async registerCourse(

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -565,7 +565,7 @@ export class CourseController {
           ERROR_MESSAGES.courseController.noSemesterFound,
         );
 
-      let course;
+      let course = null;
       try {
         // create the submitted course
         course = await CourseModel.create({

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -565,7 +565,19 @@ export class CourseController {
           ERROR_MESSAGES.courseController.noSemesterFound,
         );
 
-      let course = null;
+      // checks that course hasn't already been created
+      let course = await CourseModel.findOne({
+        where: {
+          name: courseParams.name,
+          semesterId: semester.id,
+        },
+      });
+      if (course)
+        throw new BadRequestException(
+          ERROR_MESSAGES.courseController.courseAlreadyRegistered,
+          courseParams.name,
+        );
+
       try {
         // create the submitted course
         course = await CourseModel.create({

--- a/packages/server/src/course/course.module.ts
+++ b/packages/server/src/course/course.module.ts
@@ -1,5 +1,7 @@
 import { CacheModule, Module } from '@nestjs/common';
 import { QueueModule } from '../queue/queue.module';
+import { LoginModule } from '../login/login.module';
+import { LoginCourseService } from '../login/login-course.service';
 import { CourseController } from './course.controller';
 import { CourseService } from './course.service';
 import { HeatmapService } from './heatmap.service';
@@ -8,7 +10,13 @@ import { IcalService } from './ical.service';
 
 @Module({
   controllers: [CourseController],
-  imports: [QueueModule, CacheModule.register()],
-  providers: [ICalCommand, IcalService, HeatmapService, CourseService],
+  imports: [QueueModule, LoginModule, CacheModule.register()],
+  providers: [
+    LoginCourseService,
+    ICalCommand,
+    IcalService,
+    HeatmapService,
+    CourseService,
+  ],
 })
 export class CourseModule {}

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -2,17 +2,33 @@ import {
   ERROR_MESSAGES,
   TACheckinPair,
   TACheckinTimesResponse,
+  RegisterCourseParams,
+  Role,
 } from '@koh/common';
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  BadRequestException,
+} from '@nestjs/common';
 import { partition } from 'lodash';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { QuestionModel } from 'question/question.entity';
 import { Between, Connection, In } from 'typeorm';
 import { UserCourseModel } from '../profile/user-course.entity';
+import { SemesterModel } from 'semester/semester.entity';
+import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
+import { CourseSectionMappingModel } from 'login/course-section-mapping.entity';
+import { LastRegistrationModel } from 'login/last-registration-model.entity';
+import { LoginCourseService } from '../login/login-course.service';
+import { CourseModel } from './course.entity';
 
 @Injectable()
 export class CourseService {
-  constructor(private connection: Connection) {}
+  constructor(
+    private connection: Connection,
+    private loginCourseService: LoginCourseService,
+  ) {}
 
   async getTACheckInCheckOutTimes(
     courseId: number,
@@ -99,6 +115,119 @@ export class CourseService {
         ERROR_MESSAGES.courseController.removeCourse,
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
+    }
+  }
+
+  async registerCourses(
+    body: RegisterCourseParams[],
+    userId: number,
+  ): Promise<void> {
+    // obtains the ProfSectionGroupsModel of the professor
+    const profSectionGroups = await ProfSectionGroupsModel.findOne({
+      where: { profId: userId },
+    });
+
+    // iterate over each section group registration
+    for (const courseParams of body) {
+      // finds professor's section group with matching name
+      const sectionGroup = profSectionGroups.sectionGroups.find(
+        (sg) => sg.name === courseParams.sectionGroupName,
+      );
+      if (!sectionGroup)
+        throw new BadRequestException(
+          ERROR_MESSAGES.courseController.sectionGroupNotFound,
+        );
+      const khourySemesterParsed = this.loginCourseService.parseKhourySemester(
+        sectionGroup.semester,
+      );
+      const semester = await SemesterModel.findOne({
+        where: {
+          season: khourySemesterParsed.season,
+          year: khourySemesterParsed.year,
+        },
+      });
+      if (!semester)
+        throw new BadRequestException(
+          ERROR_MESSAGES.courseController.noSemesterFound,
+        );
+
+      // checks that course hasn't already been created
+      let course = await CourseModel.findOne({
+        where: {
+          sectionGroupName: courseParams.sectionGroupName,
+          semesterId: semester.id,
+        },
+      });
+      if (course)
+        throw new BadRequestException(
+          ERROR_MESSAGES.courseController.courseAlreadyRegistered,
+          courseParams.name,
+        );
+
+      try {
+        // create the submitted course
+        course = await CourseModel.create({
+          name: courseParams.name,
+          sectionGroupName: courseParams.sectionGroupName,
+          coordinator_email: courseParams.coordinator_email,
+          icalURL: courseParams.iCalURL,
+          semesterId: semester.id,
+          enabled: true,
+          timezone: courseParams.timezone,
+        }).save();
+      } catch (err) {
+        console.error(err);
+        throw new HttpException(
+          ERROR_MESSAGES.courseController.createCourse,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      try {
+        // create CourseSectionMappings for each crn
+        new Set(sectionGroup.crns).forEach(async (crn) => {
+          await CourseSectionMappingModel.create({
+            crn: crn,
+            courseId: course.id,
+          }).save();
+        });
+      } catch (err) {
+        console.error(err);
+        throw new HttpException(
+          ERROR_MESSAGES.courseController.createCourseMappings,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      // Add UserCourse to course
+      await UserCourseModel.create({
+        userId,
+        courseId: course.id,
+        role: Role.PROFESSOR,
+      }).save();
+
+      try {
+        // Update professor's last registered semester to semester model's current semester
+        let profLastRegistered: LastRegistrationModel;
+        profLastRegistered = await LastRegistrationModel.findOne({
+          where: { profId: userId },
+        });
+        if (profLastRegistered) {
+          profLastRegistered.lastRegisteredSemester = sectionGroup.semester;
+          await profLastRegistered.save();
+        } else {
+          profLastRegistered = await LastRegistrationModel.create({
+            profId: userId,
+            lastRegisteredSemester: sectionGroup.semester,
+          }).save();
+        }
+      } catch (err) {
+        console.error(err);
+        throw new HttpException(
+          ERROR_MESSAGES.courseController.updateProfLastRegistered,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
     }
   }
 }

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -143,7 +143,7 @@ export class LoginCourseService {
   }
 
   // parses 6-digit semester code, where first 4 digits represent year and last 2 digits represent academic semester (ex: 202110)
-  private parseKhourySemester(khourySemester: string): {
+  public parseKhourySemester(khourySemester: string): {
     season: Season;
     year: number;
   } {

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -148,18 +148,11 @@ export class LoginCourseService {
     };
 
     // parsing time
-    let year: number;
-    let season: Season;
-    try {
-      year = Number(khourySemester.slice(0, 4));
-      season = courseSeasonMap[khourySemester.slice(-2)];
-      // edge case for Fall semester, included in the next academic year
-      if (season === 'Fall') {
-        year--;
-      }
-    } catch (e) {
-      console.log(e);
-      throw new Error(e);
+    let year = Number(khourySemester.slice(0, 4));
+    const season = courseSeasonMap[khourySemester.slice(-2)];
+    // edge case for Fall semester, included in the next academic year
+    if (season === 'Fall') {
+      year--;
     }
 
     return { season, year };

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -125,6 +125,37 @@ export class LoginCourseService {
     return userCourse;
   }
 
+  // parses 6-digit semester code, where first 4 digits represent year and last 2 digits represent academic semester (ex: 202110)
+  public parseKhourySemester(khourySemester: string): {
+    season: Season;
+    year: number;
+  } {
+    const courseSeasonMap = {
+      '10': 'Fall',
+      '30': 'Spring',
+      '40': 'Summer_1',
+      '50': 'Summer_Full',
+      '60': 'Summer_2',
+    };
+
+    // parsing time
+    let year: number;
+    let season: Season;
+    try {
+      year = Number(khourySemester.slice(0, 4));
+      season = courseSeasonMap[khourySemester.slice(-2)];
+      // edge case for Fall semester, included in the next academic year
+      if (season === 'Fall') {
+        year--;
+      }
+    } catch (e) {
+      console.log(e);
+      throw new Error(e);
+    }
+
+    return { season, year };
+  }
+
   private hasUserCourse(
     userCourses: UserCourseModel[],
     previousCourse: UserCourseModel,
@@ -140,27 +171,5 @@ export class LoginCourseService {
   // util functions for converting Khoury Admin data to KOH data
   private convertKhouryRole(khouryRole: 'TA' | 'Student'): Role {
     return khouryRole.toLowerCase() === 'ta' ? Role.TA : Role.STUDENT;
-  }
-
-  // parses 6-digit semester code, where first 4 digits represent year and last 2 digits represent academic semester (ex: 202110)
-  public parseKhourySemester(khourySemester: string): {
-    season: Season;
-    year: number;
-  } {
-    const courseSeasonMap = {
-      '10': 'Fall',
-      '30': 'Spring',
-      '40': 'Summer_1',
-      '50': 'Summer_Full',
-      '60': 'Summer_2',
-    };
-    // parsing time
-    let year = Number(khourySemester.slice(0, 4));
-    const season = courseSeasonMap[khourySemester.slice(-2)];
-    // edge case for Fall semester, included in the next academic year
-    if (season === 'Fall') {
-      year--;
-    }
-    return { season, year };
   }
 }

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -35,7 +35,7 @@ Object {
       "defaultMessage": null,
       "email": "user@neu.edu",
       "firstName": "User",
-      "id": 1,
+      "id": 2,
       "includeDefaultMessage": true,
       "insights": Array [
         "TotalStudents",

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -53,3 +53,11 @@ Object {
   ],
 }
 `;
+
+exports[`Course Integration POST /register_courses tests prof registering an array of courses 1`] = `
+Object {
+  "error": "Not Found",
+  "message": "Cannot POST /register_courses",
+  "statusCode": 404,
+}
+`;

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -35,7 +35,7 @@ Object {
       "defaultMessage": null,
       "email": "user@neu.edu",
       "firstName": "User",
-      "id": 2,
+      "id": 1,
       "includeDefaultMessage": true,
       "insights": Array [
         "TotalStudents",
@@ -51,13 +51,5 @@ Object {
       "photoURL": null,
     },
   ],
-}
-`;
-
-exports[`Course Integration POST /register_courses tests prof registering an array of courses 1`] = `
-Object {
-  "error": "Not Found",
-  "message": "Cannot POST /register_courses",
-  "statusCode": 404,
 }
 `;

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -598,7 +598,6 @@ describe('POST /courses/register_courses', async () => {
     {
       name: 'Underwater Basket-Weaving',
       displayName: 'Scuba',
-      semester: 'Fall 2021',
       iCalURL:
         'https://calendar.google.com/calendar/ical/yamsarecool/basic.ics',
       coordinatorEmail: 'yamsarecool@gmail.com',
@@ -607,7 +606,6 @@ describe('POST /courses/register_courses', async () => {
     {
       name: 'Underwater Basket-Weaving 2',
       displayName: 'Scuba 2',
-      semester: 'Spring 2022',
       iCalURL:
         'https://calendar.google.com/calendar/ical/potatoesarecool2/basic.ics',
       coordinatorEmail: 'potatoesarecool2@outlook.com',

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -596,7 +596,7 @@ describe('Course Integration', () => {
         name: 'Underwater Basket-Weaving 2',
       };
 
-      const semester = await SemesterFactory.create({
+      await SemesterFactory.create({
         season: 'Spring',
         year: 2022,
       });
@@ -649,28 +649,8 @@ describe('Course Integration', () => {
       const ubw2 = await CourseModel.findOne({
         sectionGroupName: 'Underwater Basket-Weaving 2',
       });
-
-      expect(ubw.name).toEqual('Scuba');
-      expect(ubw.sectionGroupName).toEqual('Underwater Basket-Weaving');
-      expect(ubw.coordinator_email).toEqual('yamsarecool@gmail.com');
-      expect(ubw.icalURL).toEqual(
-        'https://calendar.google.com/calendar/ical/yamsarecool/basic.ics',
-      );
-      expect(ubw.semesterId).toEqual(semester.id);
-      expect(ubw.enabled).toBeTruthy();
-      expect(ubw.pending).toBeFalsy();
-      expect(ubw.timezone).toEqual('America/New_York');
-
-      expect(ubw2.name).toEqual('Scuba 2');
-      expect(ubw2.sectionGroupName).toEqual('Underwater Basket-Weaving 2');
-      expect(ubw2.coordinator_email).toEqual('potatoesarecool2@outlook.com');
-      expect(ubw2.icalURL).toEqual(
-        'https://calendar.google.com/calendar/ical/potatoesarecool2/basic.ics',
-      );
-      expect(ubw2.semesterId).toEqual(semester.id);
-      expect(ubw2.enabled).toBeTruthy();
-      expect(ubw2.pending).toBeFalsy();
-      expect(ubw2.timezone).toEqual('America/Los_Angeles');
+      expect(ubw).toBeDefined();
+      expect(ubw2).toBeDefined();
 
       // checks if the registered courses have the professor as a userCourse
       const ubwProfCourse = await UserCourseModel.findOne({

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -6,6 +6,8 @@ import {
   TACheckoutResponse,
 } from '@koh/common';
 import { CourseModel } from 'course/course.entity';
+import { CourseSectionMappingModel } from 'login/course-section-mapping.entity';
+import { LastRegistrationModel } from 'login/last-registration-model.entity';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { UserCourseModel } from 'profile/user-course.entity';
 import { CourseModule } from '../src/course/course.module';
@@ -576,25 +578,35 @@ describe('Course Integration', () => {
         user: professor,
         role: Role.PROFESSOR,
       });
+
+      const CRN1 = 12345;
+      const CRN2 = 56765;
+      const CRN3 = 44444;
       const course1: KhouryProfCourse = {
-        crns: [12345, 56765, 44444],
+        crns: [CRN1, CRN2, CRN3],
         semester: '202230',
         name: 'Underwater Basket-Weaving',
       };
+
+      const CRN4 = 11111;
+      const CRN5 = 22222;
       const course2: KhouryProfCourse = {
-        crns: [11111, 22222],
+        crns: [CRN4, CRN5],
         semester: '202230',
         name: 'Underwater Basket-Weaving 2',
       };
+
       await SemesterFactory.create({
         season: 'Spring',
         year: 2022,
       });
+
       await ProfSectionGroupsFactory.create({
         prof: professor,
         profId: professor.id,
         sectionGroups: [course1, course2],
       });
+
       const registerCourses = [
         {
           sectionGroupName: 'Underwater Basket-Weaving',
@@ -638,8 +650,37 @@ describe('Course Integration', () => {
       expect(ubwProfCourse).toBeDefined();
       expect(ubw2ProfCourse).toBeDefined();
 
-      // TODO: Check CRN mappings created for each crn
-      // TODO: Check if LastRegistrationSemester with for Spring 2022
+      // Check CRN mappings created for each crn
+      const crn1ToUbwMapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN1, courseId: ubw.id },
+      });
+      const crn2ToUbwMapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN2, courseId: ubw.id },
+      });
+      const crn3ToUbwMapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN3, courseId: ubw.id },
+      });
+      const crn4ToUbwMapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN4, courseId: ubw.id },
+      });
+      expect(crn1ToUbwMapping).toBeDefined();
+      expect(crn2ToUbwMapping).toBeDefined();
+      expect(crn3ToUbwMapping).toBeDefined();
+      expect(crn4ToUbwMapping).toBeUndefined();
+      const crn4ToUbw2Mapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN4, courseId: ubw2.id },
+      });
+      const crn5ToUbw2Mapping = await CourseSectionMappingModel.findOne({
+        where: { crn: CRN5, courseId: ubw2.id },
+      });
+      expect(crn4ToUbw2Mapping).toBeDefined();
+      expect(crn5ToUbw2Mapping).toBeDefined();
+
+      // Check if prof's LastRegistrationSemester is up to date
+      const profLastRegistered = await LastRegistrationModel.findOne({
+        where: { profId: professor.id },
+      });
+      expect(profLastRegistered.lastRegisteredSemester).toEqual('202230');
     });
   });
 });

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -578,7 +578,7 @@ describe('Course Integration', () => {
       });
       const course1: KhouryProfCourse = {
         crns: [12345, 56765, 44444],
-        semester: '202210',
+        semester: '202230',
         name: 'Underwater Basket-Weaving',
       };
       const course2: KhouryProfCourse = {
@@ -586,10 +586,6 @@ describe('Course Integration', () => {
         semester: '202230',
         name: 'Underwater Basket-Weaving 2',
       };
-      await SemesterFactory.create({
-        season: 'Fall',
-        year: 2021,
-      });
       await SemesterFactory.create({
         season: 'Spring',
         year: 2022,
@@ -641,6 +637,9 @@ describe('Course Integration', () => {
       });
       expect(ubwProfCourse).toBeDefined();
       expect(ubw2ProfCourse).toBeDefined();
+
+      // TODO: Check CRN mappings created for each crn
+      // TODO: Check if LastRegistrationSemester with for Spring 2022
     });
   });
 });

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -626,10 +626,21 @@ describe('Course Integration', () => {
         },
       ];
 
+      // Counts total professor courses before registration
+      const totalProfCoursesBefore = await UserCourseModel.count({
+        where: { userId: professor.id },
+      });
+
       await supertest({ userId: professor.id })
         .post(`/courses/register_courses`)
         .send(registerCourses)
         .expect(201);
+
+      // total professor courses after registering 2 courses
+      const totalProfCourses = await UserCourseModel.count({
+        where: { userId: professor.id },
+      });
+      expect(totalProfCourses).toEqual(totalProfCoursesBefore + 2);
 
       // verify courses are created as expected
       const ubw = await CourseModel.findOne({

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -626,21 +626,10 @@ describe('Course Integration', () => {
         },
       ];
 
-      // Counts total professor courses before registration
-      const totalProfCoursesBefore = await UserCourseModel.count({
-        where: { userId: professor.id },
-      });
-
       await supertest({ userId: professor.id })
         .post(`/courses/register_courses`)
         .send(registerCourses)
         .expect(201);
-
-      // total professor courses after registering 2 courses
-      const totalProfCourses = await UserCourseModel.count({
-        where: { userId: professor.id },
-      });
-      expect(totalProfCourses).toEqual(totalProfCoursesBefore + 2);
 
       // verify courses are created as expected
       const ubw = await CourseModel.findOne({

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -1,4 +1,4 @@
-import { KhouryProfCourse, QuestionType, Role } from '@koh/common';
+import { QuestionType, Role } from '@koh/common';
 import { QuestionGroupModel } from 'question/question-group.entity';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { Factory } from 'typeorm-factory';
@@ -59,13 +59,9 @@ export const UserCourseFactory = new Factory(UserCourseModel)
   .attr('role', Role.STUDENT)
   .attr('override', false);
 
-export const KhouryProfCourseFactory = new Factory(KhouryProfCourse)
-  .attr('crns', [12345, 23456, 34567])
-  .attr('name', 'Underwater Basket-Weaving');
-
 export const ProfSectionGroupsFactory = new Factory(ProfSectionGroupsModel)
   .assocOne('prof', UserFactory)
-  .assocMany('sectionGroups', KhouryProfCourseFactory);
+  .attr('sectionGroups', []);
 
 export const QueueFactory = new Factory(QueueModel)
   .attr('room', 'Online')

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -1,4 +1,4 @@
-import { QuestionType, Role } from '@koh/common';
+import { KhouryProfCourse, QuestionType, Role } from '@koh/common';
 import { QuestionGroupModel } from 'question/question-group.entity';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { Factory } from 'typeorm-factory';
@@ -10,6 +10,7 @@ import { UserCourseModel } from '../../src/profile/user-course.entity';
 import { UserModel } from '../../src/profile/user.entity';
 import { QuestionModel } from '../../src/question/question.entity';
 import { QueueModel } from '../../src/queue/queue.entity';
+import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
 
 export const UserFactory = new Factory(UserModel)
   .attr('email', `user@neu.edu`)
@@ -57,6 +58,14 @@ export const UserCourseFactory = new Factory(UserCourseModel)
   .assocOne('course', CourseFactory)
   .attr('role', Role.STUDENT)
   .attr('override', false);
+
+export const KhouryProfCourseFactory = new Factory(KhouryProfCourse)
+  .attr('crns', [12345, 23456, 34567])
+  .attr('name', 'Underwater Basket-Weaving');
+
+export const ProfSectionGroupsFactory = new Factory(ProfSectionGroupsModel)
+  .assocOne('prof', UserFactory)
+  .assocMany('sectionGroups', KhouryProfCourseFactory);
 
 export const QueueFactory = new Factory(QueueModel)
   .attr('room', 'Online')


### PR DESCRIPTION
# Description
As part of the new login flow, this new endpoint uses a new array of `RegisterCourseParams` which allows professors to register multiple `SectionGroups` at once. (A `SectionGroup` represents a course with multiple section offerings, denoted by CRN)

- Refactors the `CourseModel` object to have a `sectionGroupName` field
- Generates `CourseSectionMappings` for each item in `sectionGroup.crns`
- Creates a `UserCourse` where professor is assigned as a user of the created course
- Updates professor's last registered semester to match the course's semester

Closes #781.
This PR was created because the [original one](https://github.com/sandboxnu/office-hours/pull/801) was closed by accident. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
New course integration test for `register_courses` endpoint.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
