### PR TITLE
Make crn column nullable

### DIFF
--- a/packages/server/migration/1642001529143-NullableCrn.ts
+++ b/packages/server/migration/1642001529143-NullableCrn.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NullableCrn1642001529143 implements MigrationInterface {
+  name = 'NullableCrn1642001529143';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "course_section_mapping_model" ALTER COLUMN "crn" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "course_section_mapping_model" ALTER COLUMN "crn" SET NOT NULL`,
+    );
+  }
+}

--- a/packages/server/src/login/course-section-mapping.entity.ts
+++ b/packages/server/src/login/course-section-mapping.entity.ts
@@ -13,7 +13,7 @@ export class CourseSectionMappingModel extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ nullable: true }) // for backwards compat
   crn: number;
 
   // Represents the course that this maps to


### PR DESCRIPTION
# Description

Past entries to the `CourseSectionMappingModel` don't have a crn, so running the migration that adds a crn column fails because the column was not nullable. This changes the `crn` column to be nullable for backwards compatibility.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
