### PR TITLE
set lastregistered sem if no courses are registered

### DIFF
--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -127,12 +127,10 @@ export class CourseService {
       where: { profId: userId },
     });
 
-    let lastRegisteredSemester: string;
-
     // iterate over each section group registration
     for (const courseParams of body) {
       // finds professor's section group with matching name
-      const sectionGroup = profSectionGroups.sectionGroups.find(
+      const sectionGroup = profSectionGroups?.sectionGroups.find(
         (sg) => sg.name === courseParams.sectionGroupName,
       );
       if (!sectionGroup)
@@ -207,8 +205,6 @@ export class CourseService {
         courseId: course.id,
         role: Role.PROFESSOR,
       }).save();
-
-      lastRegisteredSemester = sectionGroup.semester;
     }
 
     try {
@@ -218,10 +214,8 @@ export class CourseService {
         where: { profId: userId },
       });
 
-      // if the professor did not register anything, then find the current semester
-      if (!lastRegisteredSemester) {
-        lastRegisteredSemester = this.getCurrentKhourySemester();
-      }
+      const lastRegisteredSemester =
+        profSectionGroups?.sectionGroups[0]?.semester;
 
       if (profLastRegistered) {
         profLastRegistered.lastRegisteredSemester = lastRegisteredSemester;
@@ -238,38 +232,6 @@ export class CourseService {
         ERROR_MESSAGES.courseController.updateProfLastRegistered,
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
-    }
-  }
-
-  // TODO: harden course registration for Summer Courses. Last Registered Semester can't tell between summer 1 and summer full.
-  public getCurrentKhourySemester = (): string => {
-    const courseSeasonMap = {
-      Fall: '10',
-      Spring: '30',
-      Summer_1: '40',
-      Summer_Full: '50',
-      Summer_2: '60',
-    };
-    const now = new Date();
-    let year = now.getFullYear();
-    const season = this.monthToSeason(now.getMonth() + 1);
-
-    if (season === 'Fall') {
-      year -= 1;
-    }
-
-    return `${year}${courseSeasonMap[season]}`;
-  };
-
-  private monthToSeason(month: number): string {
-    if (1 <= month && month <= 4) {
-      return 'Spring';
-    } else if (5 <= month && month <= 6) {
-      return 'Summer_1'; // i have no idea how to differentiate between this and summer full
-    } else if (6 <= month && month <= 7) {
-      return 'Summer_2';
-    } else {
-      return 'Fall';
     }
   }
 }

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -219,7 +219,7 @@ export class CourseService {
       });
 
       // if the professor did not register anything, then find the current semester
-      if (!profLastRegistered) {
+      if (!lastRegisteredSemester) {
         lastRegisteredSemester = this.getCurrentKhourySemester();
       }
 
@@ -241,12 +241,8 @@ export class CourseService {
     }
   }
 
-  //TODO: harden course registration for Summer Courses. Last Registered Semester can't tell between summer 1 and summer full.
-  getCurrentKhourySemester = (): string => {
-    const now = new Date();
-    let year = now.getFullYear();
-    const season = this.monthToSeason(now.getMonth());
-
+  // TODO: harden course registration for Summer Courses. Last Registered Semester can't tell between summer 1 and summer full.
+  public getCurrentKhourySemester = (): string => {
     const courseSeasonMap = {
       Fall: '10',
       Spring: '30',
@@ -254,6 +250,9 @@ export class CourseService {
       Summer_Full: '50',
       Summer_2: '60',
     };
+    const now = new Date();
+    let year = now.getFullYear();
+    const season = this.monthToSeason(now.getMonth() + 1);
 
     if (season === 'Fall') {
       year -= 1;

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -697,6 +697,7 @@ describe('Course Integration', () => {
 
     it('tests prof registering no courses and last registered semester is still updated', async () => {
       const professor = await UserFactory.create();
+      const newSem = '202230';
       await UserCourseFactory.create({
         course: await CourseFactory.create(),
         user: professor,
@@ -706,6 +707,17 @@ describe('Course Integration', () => {
       await SemesterFactory.create({
         season: 'Spring',
         year: 2022,
+      });
+
+      await ProfSectionGroupsFactory.create({
+        prof: professor,
+        sectionGroups: [
+          {
+            name: 'Fundies 1',
+            crns: [123, 456],
+            semester: newSem,
+          },
+        ],
       });
 
       const noCourses = [];
@@ -725,7 +737,7 @@ describe('Course Integration', () => {
       const profLastRegistered = await LastRegistrationModel.findOne({
         where: { profId: professor.id },
       });
-      expect(profLastRegistered.lastRegisteredSemester).toEqual('202230');
+      expect(profLastRegistered.lastRegisteredSemester).toEqual(newSem);
     });
 
     it('shows error if user enters course that is already registered', async () => {

--- a/packages/server/test/course.integration.ts
+++ b/packages/server/test/course.integration.ts
@@ -694,5 +694,127 @@ describe('Course Integration', () => {
       });
       expect(profLastRegistered.lastRegisteredSemester).toEqual('202230');
     });
+
+    it('tests prof registering no courses and last registered semester is still updated', async () => {
+      const professor = await UserFactory.create();
+      await UserCourseFactory.create({
+        course: await CourseFactory.create(),
+        user: professor,
+        role: Role.PROFESSOR,
+      });
+
+      await SemesterFactory.create({
+        season: 'Spring',
+        year: 2022,
+      });
+
+      const noCourses = [];
+
+      await supertest({ userId: professor.id })
+        .post(`/courses/register_courses`)
+        .send(noCourses)
+        .expect(201);
+
+      // total professor courses after registering no courses should remain the same (one course: CS2500)
+      const totalProfCourses = await UserCourseModel.count({
+        where: { userId: professor.id },
+      });
+      expect(totalProfCourses).toEqual(1);
+
+      // Check if prof's LastRegistrationSemester is up to date
+      const profLastRegistered = await LastRegistrationModel.findOne({
+        where: { profId: professor.id },
+      });
+      expect(profLastRegistered.lastRegisteredSemester).toEqual('202230');
+    });
+
+    it('shows error if user enters course that is already registered', async () => {
+      const professor = await UserFactory.create();
+      await UserCourseFactory.create({
+        course: await CourseFactory.create(),
+        user: professor,
+        role: Role.PROFESSOR,
+      });
+
+      const semester = await SemesterFactory.create({
+        season: 'Spring',
+        year: 2022,
+      });
+
+      const CRN1 = 12345;
+      const course1: KhouryProfCourse = {
+        crns: [CRN1],
+        semester: '202230',
+        name: 'Life is Not a Highway',
+      };
+
+      const CRN4 = 11111;
+      const CRN5 = 22222;
+      const course2: KhouryProfCourse = {
+        crns: [CRN4, CRN5],
+        semester: '202230',
+        name: 'Underwater Basket-Weaving 2',
+      };
+
+      await SemesterFactory.create({
+        season: 'Spring',
+        year: 2022,
+      });
+
+      await ProfSectionGroupsFactory.create({
+        prof: professor,
+        profId: professor.id,
+        sectionGroups: [course1, course2],
+      });
+
+      // course was already registered before
+      await CourseModel.create({
+        name: 'life',
+        sectionGroupName: 'Life is Not a Highway',
+        coordinator_email: 'squidward@bikinibottom.com',
+        icalURL: '',
+        semesterId: semester.id,
+        enabled: true,
+        timezone: 'America/Los_Angeles',
+      }).save();
+
+      const registerCourses = [
+        {
+          sectionGroupName: 'Underwater Basket-Weaving 2',
+          name: 'Scuba 2',
+          iCalURL:
+            'https://calendar.google.com/calendar/ical/potatoesarecool2/basic.ics',
+          coordinator_email: 'potatoesarecool2@outlook.com',
+          timezone: 'America/Los_Angeles',
+        },
+        {
+          sectionGroupName: 'Life is Not a Highway',
+          name: 'Life',
+          iCalURL:
+            'https://calendar.google.com/calendar/ical/yamsarecool/basic.ics',
+          coordinator_email: 'yamsarecool@gmail.com',
+          timezone: 'America/New_York',
+        },
+      ];
+
+      const response = await supertest({ userId: professor.id })
+        .post(`/courses/register_courses`)
+        .send(registerCourses)
+        .expect(400);
+      expect(response.body.message).toEqual(
+        'One or more of the courses is already registered',
+      );
+
+      // verify course is created as expected before error
+      const ubw2 = await CourseModel.findOne({
+        sectionGroupName: 'Underwater Basket-Weaving 2',
+      });
+      // verify existing course still exists
+      const life = await CourseModel.findOne({
+        sectionGroupName: 'Life is Not a Highway',
+      });
+      expect(ubw2).toBeDefined();
+      expect(life).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
If profs decide not to register any new courses (this can be bc another professor has already registered on their behalf), we do not set the last registered semester for them. They'll see the apply page every time they log in. 

We set the last registered semester inside the for loop when analyzing each section group in the list. This PR pulls it out of the loop, which now means if the professor does not select any courses to register, we set the lastRegisteredSemester to the current semester's Khoury code (I made a new helper to find this). 

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Closes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
