### PR TITLE
Prevent error if prof already has sectionGroups saved

### DIFF
--- a/packages/app/components/Apply/EditCourse.tsx
+++ b/packages/app/components/Apply/EditCourse.tsx
@@ -85,7 +85,8 @@ export default function EditCourse({
 
         <Form.Item
           name="coordinator_email"
-          label="Coordinator Email"
+          label="Course Contact Email"
+          tooltip="This can be your email or that of a course coordinator's"
           rules={[
             {
               required: true,

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -1,4 +1,10 @@
-import { isKhouryCourse, KhouryDataParams, Role, Season } from '@koh/common';
+import {
+  isKhouryCourse,
+  KhouryDataParams,
+  KhouryProfCourse,
+  Role,
+  Season,
+} from '@koh/common';
 import { Injectable } from '@nestjs/common';
 import { CourseModel } from 'course/course.entity';
 import { CourseSectionMappingModel } from 'login/course-section-mapping.entity';
@@ -83,10 +89,17 @@ export class LoginCourseService {
 
     // If Prof, save the JSON data
     if (info.courses[0] && !isKhouryCourse(info.courses[0])) {
-      await ProfSectionGroupsModel.create({
-        profId: user.id,
-        sectionGroups: info.courses,
-      }).save();
+      const profSectionGroups = await ProfSectionGroupsModel.findOne({
+        where: { profId: user.id },
+      });
+      if (profSectionGroups) {
+        profSectionGroups.sectionGroups = info.courses as KhouryProfCourse[];
+      } else {
+        await ProfSectionGroupsModel.create({
+          profId: user.id,
+          sectionGroups: info.courses,
+        }).save();
+      }
     }
 
     user.courses = userCourses;


### PR DESCRIPTION
# Description

this was a rookie mistake on my part - if the prof has logged in before and already had sectionGroups saved in our DB, we need to modify the entry instead of creating a new one. Otherwise you get a foreign key constraint violation. 

Closes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
