### PR TITLE
Handle Registering for Multiple Semesters (Summer Shenanigans)

### DIFF
--- a/packages/server/src/login/last-registration-model.entity.ts
+++ b/packages/server/src/login/last-registration-model.entity.ts
@@ -7,6 +7,7 @@ import {
   JoinColumn,
   OneToOne,
 } from 'typeorm';
+import { Season } from '@koh/common';
 
 @Entity('last_registration_model')
 export class LastRegistrationModel extends BaseEntity {
@@ -23,3 +24,11 @@ export class LastRegistrationModel extends BaseEntity {
   @Column('text')
   lastRegisteredSemester: string; // same format as what's passed by Admin
 }
+
+export const khourySemesterCodes: Record<Season, string> = {
+  Fall: '10',
+  Spring: '30',
+  Summer_1: '40',
+  Summer_Full: '50',
+  Summer_2: '60',
+};

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -13,6 +13,7 @@ import { UserModel } from 'profile/user.entity';
 import { SemesterModel } from 'semester/semester.entity';
 import { Connection } from 'typeorm';
 import { ProfSectionGroupsModel } from './prof-section-groups.entity';
+import { khourySemesterCodes } from './last-registration-model.entity';
 
 @Injectable()
 export class LoginCourseService {
@@ -152,17 +153,12 @@ export class LoginCourseService {
     season: Season;
     year: number;
   } {
-    const courseSeasonMap = {
-      '10': 'Fall',
-      '30': 'Spring',
-      '40': 'Summer_1',
-      '50': 'Summer_Full',
-      '60': 'Summer_2',
-    };
-
     // parsing time
     let year = Number(khourySemester.slice(0, 4));
-    const season = courseSeasonMap[khourySemester.slice(-2)];
+    const semesterCode = khourySemester.slice(-2);
+    const season = Object.keys(khourySemesterCodes).find(
+      (key) => khourySemesterCodes[key] === semesterCode,
+    ) as Season;
     // edge case for Fall semester, included in the next academic year
     if (season === 'Fall') {
       year--;

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -26,6 +26,7 @@ export class ProfileService {
         profId: userId,
       },
     });
+    const lastRegisteredSemester = lastRegistered?.lastRegisteredSemester;
 
     if (!profCourses) return; // not a professor
 
@@ -35,10 +36,8 @@ export class ProfileService {
       // current semester does not match last time prof registered, there may be pending courses
       if (
         c.crns.length !== 0 &&
-        !this.isSameRegistrationTime(
-          c.semester,
-          lastRegistered?.lastRegisteredSemester,
-        )
+        (!lastRegisteredSemester || // lastRegistered doesnt exist if prof has never registered before
+          !this.isSameRegistrationTime(c.semester, lastRegisteredSemester))
       ) {
         const courseCRN = c.crns[0];
         const profCourse = await this.loginCourseService.courseCRNToCourse(

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -58,13 +58,13 @@ export class ProfileService {
     const year2 = Number(semester2.slice(0, 4));
     const semesterCode1 = semester1.slice(-2);
     const semesterCode2 = semester2.slice(-2);
+    const summer1 = khourySemesterCodes['Summer_1'];
+    const summerFull = khourySemesterCodes['Summer_Full'];
     // we want to treat Summer 1 and Summer Full as the same window
     // for profs to register classes for both at the same time
     if (
-      (semesterCode1 === khourySemesterCodes['Summer_1'] ||
-        semesterCode2 === khourySemesterCodes['Summer_1']) &&
-      (semesterCode1 === khourySemesterCodes['Summer_Full'] ||
-        semesterCode2 === khourySemesterCodes['Summer_Full'])
+      (semesterCode1 === summer1 || semesterCode2 === summer1) &&
+      (semesterCode1 === summerFull || semesterCode2 === summerFull)
     ) {
       return year1 === year2;
     }


### PR DESCRIPTION
# Description

Refactors our pending courses parsing to consider Summer 1 and Summer Full to be the same semester.

Previously, our redirect to the course onboarding flow is based on if a professor's last registered semester is different than the semester of the courses we receive from Khoury admin. This raises the issue of Summer 1/Summer Fall registration as if you register for both at the same time, it was unclear which to set `lastRegisteredSemester` to and how to handle that when later registering for Summer 2 classes.

Closes #820 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has not been manually tested but we wrote two unit tests in `profile.service.spec.ts` for the case in which we want Summer 2 courses to be pushed to pending courses and `lastRegisteredSemester` is either Summer 1 or Summer 2. All the previous unit tests pass still as well so we probably didn't break anything.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
