### PR TITLE
Cut off long questions on student view

### DIFF
--- a/packages/app/components/Queue/QueueUtils.tsx
+++ b/packages/app/components/Queue/QueueUtils.tsx
@@ -1,0 +1,8 @@
+// Shared functions across queue components. Kinda sad rn pls add :(
+
+export function truncate(string: string, length: number) {
+  if (string.length > length) {
+    return string.substring(0, length - 3) + "...";
+  }
+  return string;
+}

--- a/packages/app/components/Queue/Student/StudentQueueCard.tsx
+++ b/packages/app/components/Queue/Student/StudentQueueCard.tsx
@@ -4,6 +4,7 @@ import { ReactElement } from "react";
 import styled from "styled-components";
 import { getWaitTime } from "../../../utils/TimeUtil";
 import { CenterRow, Text } from "../QueueCardSharedComponents";
+import { truncate } from "../QueueUtils";
 
 const HorizontalStudentCard = styled(Card)`
   margin-bottom: 8px;
@@ -43,7 +44,7 @@ export default function StudentQueueCard({
           <Text>{rank}</Text>
         </Col>
         <Col flex="1 1">
-          <Text>{question.text}</Text>
+          <Text>{truncate(question.text, 150)}</Text>
         </Col>
         <Col flex="0 0 80px">
           <Text>{getWaitTime(question)}</Text>

--- a/packages/app/components/Queue/TA/TAQueueListItem.tsx
+++ b/packages/app/components/Queue/TA/TAQueueListItem.tsx
@@ -5,13 +5,7 @@ import React, { ReactElement } from "react";
 import styled from "styled-components";
 import { getWaitTime } from "../../../utils/TimeUtil";
 import { KOHAvatar } from "../../common/SelfAvatar";
-
-function truncate(string: string, length: number) {
-  if (string.length > length) {
-    return string.substring(0, length - 3) + "...";
-  }
-  return string;
-}
+import { truncate } from "../QueueUtils";
 
 export const Container = styled.div<{ selected: boolean }>`
   display: flex;


### PR DESCRIPTION
# Description

For TAs, questions longer than 80 characters were being cut off and replaced with "...". This adds that functionality for students but for 150 characters because the question spans across the entire screen instead of a smaller column. I moved the truncate function out of `TAQueueListItem` and into a new utils file for queues for export and importing into `StudentQueueCard`.

Closes #305

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I didn't write tests but you can manually test by making a question that spans multiple lines as a student and seeing that it gets truncated properly.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
