### PR TITLE
Add spinner to indicate app loading

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -7,8 +7,8 @@ import { Spin } from "antd";
 
 export default function Home(): ReactElement {
   const profile: User = useProfile();
-  const redirected = useHomePageRedirect();
-  if (profile && !redirected) {
+  const didRedirect = useHomePageRedirect();
+  if (profile && !didRedirect) {
     Router.push("/nocourses");
   } else {
     return (

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -3,13 +3,26 @@ import Router from "next/router";
 import { ReactElement } from "react";
 import { useHomePageRedirect } from "../hooks/useHomePageRedirect";
 import { useProfile } from "../hooks/useProfile";
+import { Spin } from "antd";
 
 export default function Home(): ReactElement {
   const profile: User = useProfile();
-  const didRedirect = useHomePageRedirect();
-  if (profile && !didRedirect) {
+  const redirected = useHomePageRedirect();
+  if (profile && !redirected) {
     Router.push("/nocourses");
+  } else {
+    return (
+      <div
+        style={{
+          position: "absolute",
+          left: "50%",
+          top: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        <Spin tip="Loading..." size="large" />
+      </div>
+    );
   }
-
   return <div />;
 }


### PR DESCRIPTION
# Description

Application now shows a loading spinner instead of flashing the no courses page temporarily when a user logs in

Makes login look a little cleaner

Closes #828

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A: Logged in with student account in dev and loading spinner showed before opening homepage
- [ ] Test B: Logged in with student account with no courses in dev and loading spinner showed before showing no courses page

<img width="1440" alt="Screen Shot 2022-02-09 at 12 15 56 PM" src="https://user-images.githubusercontent.com/39414740/153254148-9e803983-a403-43af-90e8-4119f8708c23.png">

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
