### PR TITLE
Make sure staffList is fetched when using queue.checkIsOpen()

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -875,6 +875,7 @@ export const ERROR_MESSAGES = {
     saveQueue: "Unable to save queue",
     cleanQueue: "Unable to clean queue",
     cannotCloseQueue: "Unable to close professor queue as a TA",
+    missingStaffList: "Stafflist relation not present on Queue",
   },
   queueRoleGuard: {
     queueNotFound: "Queue not found",

--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -17,6 +17,8 @@ import { CourseModel } from '../course/course.entity';
 import { OfficeHourModel } from '../course/office-hour.entity';
 import { UserModel } from '../profile/user.entity';
 import { QuestionModel } from '../question/question.entity';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ERROR_MESSAGES } from '@koh/common';
 
 interface TimeInterval {
   startTime: Date;
@@ -74,8 +76,14 @@ export class QueueModel extends BaseEntity {
   isOpen: boolean;
 
   async checkIsOpen(): Promise<boolean> {
-    this.isOpen =
-      this.staffList && this.staffList.length > 0 && !this.isDisabled;
+    if (!this.staffList) {
+      console.error(ERROR_MESSAGES.queueController.missingStaffList, this.id);
+      throw new HttpException(
+        ERROR_MESSAGES.queueController.missingStaffList,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    this.isOpen = this.staffList.length > 0 && !this.isDisabled;
     return this.isOpen;
   }
 


### PR DESCRIPTION
# Description
Given that the checkIsOpen() method on the QueueModel now basically only depends on if there are people in the stafflist, it becomes pretty important that the stafflist relation is fetched when using this method - otherwise it returns the wrong result where it looks like the queue is not open because the stafflist array is undefined. 

I found this issue while working with Vera on #661 - the alerts service wasn't fetching the stafflist array ([now fixed](https://github.com/sandboxnu/office-hours/blob/vk-fix-fix-alerts/packages/server/src/alerts/alerts.service.ts#L29)), so alerts were getting improperly purged when the queue was actually still open. 

This PR just has the checkIsOpen() method throw an error if the staffList field doesn't exist - this isn't entirely ideal, as you won't realize you've forgotten the stafflist until the app actually runs. I tried seeing if there is a way to fetch relations on an object that you already got back from the ORM (so that checkIsOpen can just add the staffList to the queue if its not there), but I couldn't find anything. If anyone knows of something that would work lmk tho

As part of this I also looked for other usages of checkIsOpen() that were not fetching the stafflist - I didnt find anything, so the only alerts service bug should be fixed when that work gets merged in. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
