### PR TITLE
Backfill sectionGroupName

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -7,8 +7,8 @@ import { Spin } from "antd";
 
 export default function Home(): ReactElement {
   const profile: User = useProfile();
-  const redirected = useHomePageRedirect();
-  if (profile && !redirected) {
+  const didRedirect = useHomePageRedirect();
+  if (profile && !didRedirect) {
     Router.push("/nocourses");
   } else {
     return (

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -10,5 +10,6 @@ export default function Home(): ReactElement {
   if (profile && !didRedirect) {
     Router.push("/nocourses");
   }
+
   return <div />;
 }

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -3,13 +3,26 @@ import Router from "next/router";
 import { ReactElement } from "react";
 import { useHomePageRedirect } from "../hooks/useHomePageRedirect";
 import { useProfile } from "../hooks/useProfile";
+import { Spin } from "antd";
 
 export default function Home(): ReactElement {
   const profile: User = useProfile();
-  const didRedirect = useHomePageRedirect();
-  if (profile && !didRedirect) {
+  const redirected = useHomePageRedirect();
+  if (profile && !redirected) {
     Router.push("/nocourses");
+  } else {
+    return (
+      <div
+        style={{
+          position: "absolute",
+          left: "50%",
+          top: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        <Spin tip="Loading..." size="large" />
+      </div>
+    );
   }
-
   return <div />;
 }

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -3,26 +3,12 @@ import Router from "next/router";
 import { ReactElement } from "react";
 import { useHomePageRedirect } from "../hooks/useHomePageRedirect";
 import { useProfile } from "../hooks/useProfile";
-import { Spin } from "antd";
 
 export default function Home(): ReactElement {
   const profile: User = useProfile();
   const didRedirect = useHomePageRedirect();
   if (profile && !didRedirect) {
     Router.push("/nocourses");
-  } else {
-    return (
-      <div
-        style={{
-          position: "absolute",
-          left: "50%",
-          top: "50%",
-          transform: "translate(-50%, -50%)",
-        }}
-      >
-        <Spin tip="Loading..." size="large" />
-      </div>
-    );
   }
   return <div />;
 }

--- a/packages/server/src/backfill/backfill-section-group-name.ts
+++ b/packages/server/src/backfill/backfill-section-group-name.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { CourseModel } from 'course/course.entity';
+import { Command } from 'nestjs-command';
+
+@Injectable()
+export class BackfillSectionGroupName {
+  @Command({
+    command: 'backfill:section-group-name',
+    describe:
+      'set the sectionGroupName of older courses as the same as the course name',
+    autoExit: true,
+  })
+  async fix(): Promise<void> {
+    await CourseModel.createQueryBuilder()
+      .update()
+      .set({ sectionGroupName: () => 'name' })
+      .where('sectionGroupName IS NULL')
+      .execute();
+  }
+}

--- a/packages/server/src/backfill/backfill-section-group-name.ts
+++ b/packages/server/src/backfill/backfill-section-group-name.ts
@@ -16,6 +16,6 @@ export class BackfillSectionGroupName {
       .set({ sectionGroupName: () => 'name' })
       .where('sectionGroupName IS NULL')
       .execute();
-    console.log(`Set sectionGroupName for ${result.affected} rows courses`);
+    console.log(`Set sectionGroupName for ${result.affected} courses`);
   }
 }

--- a/packages/server/src/backfill/backfill-section-group-name.ts
+++ b/packages/server/src/backfill/backfill-section-group-name.ts
@@ -16,6 +16,6 @@ export class BackfillSectionGroupName {
       .set({ sectionGroupName: () => 'name' })
       .where('sectionGroupName IS NULL')
       .execute();
-    console.log(`${result.affected} rows updated`);
+    console.log(`Set sectionGroupName for ${result.affected} rows courses`);
   }
 }

--- a/packages/server/src/backfill/backfill-section-group-name.ts
+++ b/packages/server/src/backfill/backfill-section-group-name.ts
@@ -11,10 +11,11 @@ export class BackfillSectionGroupName {
     autoExit: true,
   })
   async fix(): Promise<void> {
-    await CourseModel.createQueryBuilder()
+    const result = await CourseModel.createQueryBuilder()
       .update()
       .set({ sectionGroupName: () => 'name' })
       .where('sectionGroupName IS NULL')
       .execute();
+    console.log(`${result.affected} rows updated`);
   }
 }

--- a/packages/server/src/backfill/backfill.module.ts
+++ b/packages/server/src/backfill/backfill.module.ts
@@ -5,6 +5,7 @@ import { BackfillDefaultUserTeamsMessages } from './backfill-default-user-teams-
 import { BackfillHuskyEmailsAsNortheastern } from './backfill-husky-emails-to-northeastern';
 import { BackfillPhoneNotifs } from './backfill-phone-notifs.command';
 import { BackfillQuestionGroupable } from './backfill-question-groupable';
+import { BackfillSectionGroupName } from './backfill-section-group-name';
 import { BackfillUserInsights } from './backfill-user-insights.command';
 import { BackfillMakeEmptyPhotoURLNull } from './make-empty-photourl-null.command';
 
@@ -18,6 +19,7 @@ import { BackfillMakeEmptyPhotoURLNull } from './make-empty-photourl-null.comman
     BackfillHuskyEmailsAsNortheastern,
     BackfillQuestionGroupable,
     BackfillUserInsights,
+    BackfillSectionGroupName,
   ],
 })
 export class BackfillModule {}


### PR DESCRIPTION
# Description

Wrote a quick backfill to fill in the sectionGroupName column in course_model  for old cases where it's null

Allows that column to be marked non-nullable

Closes #793

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] 
# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [] Test A: Ran backfill locally through yarn cli and saw that dev table was updated correctly. 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
