### PR TITLE
Fixing Alerts flow

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -247,9 +247,8 @@ class APIClient {
       this.req("GET", `/api/v1/alerts/${courseId}`),
     create: async (params: CreateAlertParams): Promise<CreateAlertResponse> =>
       this.req("POST", `/api/v1/alerts`, CreateAlertResponse, params),
-    close: async (alertId: number): Promise<void> => {
-      this.req("PATCH", `/api/v1/alerts/${alertId}`);
-    },
+    close: async (alertId: number): Promise<void> =>
+      this.req("PATCH", `/api/v1/alerts/${alertId}`),
   };
 
   constructor(baseURL = "") {

--- a/packages/app/components/Nav/AlertsContainer.tsx
+++ b/packages/app/components/Nav/AlertsContainer.tsx
@@ -20,10 +20,12 @@ export default function AlertsContainer({
   const handleClose = async (alertId, courseId, queueId) => {
     await API.alerts.close(alertId);
 
-    setTimeout(async () => {
-      await mutateAlerts();
-      router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
-    }, 100);
+    await mutateAlerts();
+    router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
+    // setTimeout(async () => {
+    //   await mutateAlerts();
+    //   router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
+    // }, 100);
   };
 
   const alertDivs = alerts?.map((alert) => {

--- a/packages/app/components/Nav/AlertsContainer.tsx
+++ b/packages/app/components/Nav/AlertsContainer.tsx
@@ -22,10 +22,6 @@ export default function AlertsContainer({
 
     await mutateAlerts();
     router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
-    // setTimeout(async () => {
-    //   await mutateAlerts();
-    //   router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
-    // }, 100);
   };
 
   const alertDivs = alerts?.map((alert) => {

--- a/packages/app/components/Nav/AlertsContainer.tsx
+++ b/packages/app/components/Nav/AlertsContainer.tsx
@@ -19,7 +19,11 @@ export default function AlertsContainer({
 
   const handleClose = async (alertId, courseId, queueId) => {
     await API.alerts.close(alertId);
-    mutateAlerts();
+    // TODO: literally no clue why you need to call the GET endpoint twice in order for
+    // the new alerts list to be correctly fetched. For some reason the first call
+    // returns the old list containing the already resolved alert
+    await API.alerts.get(courseId);
+    await mutateAlerts();
     router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
   };
 

--- a/packages/app/components/Nav/AlertsContainer.tsx
+++ b/packages/app/components/Nav/AlertsContainer.tsx
@@ -19,12 +19,11 @@ export default function AlertsContainer({
 
   const handleClose = async (alertId, courseId, queueId) => {
     await API.alerts.close(alertId);
-    // TODO: literally no clue why you need to call the GET endpoint twice in order for
-    // the new alerts list to be correctly fetched. For some reason the first call
-    // returns the old list containing the already resolved alert
-    await API.alerts.get(courseId);
-    await mutateAlerts();
-    router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
+
+    setTimeout(async () => {
+      await mutateAlerts();
+      router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`);
+    }, 100);
   };
 
   const alertDivs = alerts?.map((alert) => {

--- a/packages/app/components/Queue/Student/StudentQueue.tsx
+++ b/packages/app/components/Queue/Student/StudentQueue.tsx
@@ -82,9 +82,13 @@ const CenterRow = styled(Row)`
 
 interface StudentQueueProps {
   qid: number;
+  cid: number;
 }
 
-export default function StudentQueue({ qid }: StudentQueueProps): ReactElement {
+export default function StudentQueue({
+  qid,
+  cid,
+}: StudentQueueProps): ReactElement {
   const { queue } = useQueue(qid);
   const { questions, mutateQuestions } = useQuestions(qid);
   const { studentQuestion, studentQuestionIndex } = useStudentQuestion(qid);
@@ -103,15 +107,14 @@ export default function StudentQueue({ qid }: StudentQueueProps): ReactElement {
 
   const router = useRouter();
   const editQuestionQueryParam = Boolean(router.query.edit_question as string);
-  const [firstLanding, setFirstLanding] = useState(true);
 
   useEffect(() => {
-    if (editQuestionQueryParam && firstLanding && studentQuestion) {
+    if (editQuestionQueryParam && studentQuestion) {
       mutate(`/api/v1/queues/${qid}/questions`);
       setPopupEditQuestion(true);
-      setFirstLanding(false);
+      router.push(`/course/${cid}/queue/${qid}`);
     }
-  }, [editQuestionQueryParam, qid, studentQuestion, firstLanding]);
+  }, [editQuestionQueryParam, qid, studentQuestion]);
 
   const studentQuestionId = studentQuestion?.id;
   const studentQuestionStatus = studentQuestion?.status;

--- a/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
+++ b/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
@@ -1,12 +1,13 @@
 import { CheckOutlined } from "@ant-design/icons";
 import { API } from "@koh/api-client";
-import { QuestionGroup } from "@koh/common";
+import { QuestionGroup, RephraseQuestionPayload } from "@koh/common";
 import { Tooltip } from "antd";
 import React, { ReactElement } from "react";
 import { FinishHelpingButton } from "../../Banner";
 import { Header } from "../TAQueueDetail";
 import TAQueueDetailQuestion from "../TAQueueDetailQuestion";
 import { Description } from "./AllQuestionsChecklist";
+import { useQuestions } from "../../../../hooks/useQuestions";
 
 export function CurrentGroupList({
   group,
@@ -17,6 +18,11 @@ export function CurrentGroupList({
   queueId: number;
   courseId: number;
 }): ReactElement {
+  const { questions } = useQuestions(queueId);
+  const unresolvedAlerts = questions?.unresolvedAlerts?.map(
+    (payload) => (payload as RephraseQuestionPayload).questionId
+  );
+
   return (
     <div>
       <Header>
@@ -44,7 +50,7 @@ export function CurrentGroupList({
             queueId={queueId}
             showName
             showButtons
-            hasUnresolvedRephraseAlert={false}
+            hasUnresolvedRephraseAlert={unresolvedAlerts.includes(q.id)}
           />
         </div>
       ))}

--- a/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
+++ b/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
@@ -44,6 +44,7 @@ export function CurrentGroupList({
             queueId={queueId}
             showName
             showButtons
+            hasUnresolvedRephraseAlert={false}
           />
         </div>
       ))}

--- a/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
+++ b/packages/app/components/Queue/TA/QuestionGrouping/CurrentGroupList.tsx
@@ -1,13 +1,12 @@
 import { CheckOutlined } from "@ant-design/icons";
 import { API } from "@koh/api-client";
-import { QuestionGroup, RephraseQuestionPayload } from "@koh/common";
+import { QuestionGroup } from "@koh/common";
 import { Tooltip } from "antd";
 import React, { ReactElement } from "react";
 import { FinishHelpingButton } from "../../Banner";
 import { Header } from "../TAQueueDetail";
 import TAQueueDetailQuestion from "../TAQueueDetailQuestion";
 import { Description } from "./AllQuestionsChecklist";
-import { useQuestions } from "../../../../hooks/useQuestions";
 
 export function CurrentGroupList({
   group,
@@ -18,11 +17,6 @@ export function CurrentGroupList({
   queueId: number;
   courseId: number;
 }): ReactElement {
-  const { questions } = useQuestions(queueId);
-  const unresolvedAlerts = questions?.unresolvedAlerts?.map(
-    (payload) => (payload as RephraseQuestionPayload).questionId
-  );
-
   return (
     <div>
       <Header>
@@ -50,7 +44,7 @@ export function CurrentGroupList({
             queueId={queueId}
             showName
             showButtons
-            hasUnresolvedRephraseAlert={unresolvedAlerts.includes(q.id)}
+            hasUnresolvedRephraseAlert={false}
           />
         </div>
       ))}

--- a/packages/app/components/Queue/TA/TAQueueDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetail.tsx
@@ -26,10 +26,12 @@ export default function TAQueueDetail({
   courseId,
   queueId,
   question,
+  hasUnresolvedRephraseAlert,
 }: {
   courseId: number;
   queueId: number;
   question: Question;
+  hasUnresolvedRephraseAlert: boolean;
 }): ReactElement {
   return (
     <Container>
@@ -43,6 +45,7 @@ export default function TAQueueDetail({
             courseId={courseId}
             queueId={queueId}
             question={question}
+            hasUnresolvedRephraseAlert={hasUnresolvedRephraseAlert}
           />
         </div>
       </Header>

--- a/packages/app/components/Queue/TA/TAQueueDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetail.tsx
@@ -53,6 +53,7 @@ export default function TAQueueDetail({
         courseId={courseId}
         question={question}
         queueId={queueId}
+        hasUnresolvedRephraseAlert={hasUnresolvedRephraseAlert}
       />
     </Container>
   );

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -56,10 +56,6 @@ export default function TAQueueDetailButtons({
   );
   const { isCheckedIn, isHelping } = useTAInQueueInfo(queueId);
 
-  const rephraseTooltipTitle = hasUnresolvedRephraseAlert
-    ? "The student has already been asked to rephrase their question"
-    : "Ask the student to add more detail to their question";
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const sendRephraseAlert = async () => {
     const payload: RephraseQuestionPayload = {
@@ -146,6 +142,21 @@ export default function TAQueueDetailButtons({
         return [true, "Help Student"];
       }
     })();
+    const [canRephrase, rephraseTooltip] = ((): [boolean, string] => {
+      if (!isCheckedIn) {
+        return [
+          false,
+          "You must check in to ask this student to rephrase their question",
+        ];
+      } else if (hasUnresolvedRephraseAlert) {
+        return [
+          false,
+          "The student has already been asked to rephrase their question",
+        ];
+      } else {
+        return [true, "Ask the student to add more detail to their question"];
+      }
+    })();
     return (
       <>
         <Popconfirm
@@ -181,20 +192,14 @@ export default function TAQueueDetailButtons({
             </span>
           </Tooltip>
         </Popconfirm>
-        <Tooltip
-          title={
-            isCheckedIn
-              ? rephraseTooltipTitle
-              : "You must check in to ask this student to rephrase their question"
-          }
-        >
+        <Tooltip title={rephraseTooltip}>
           <span>
             <BannerOrangeButton
               shape="circle"
               icon={<QuestionOutlined />}
               onClick={sendRephraseAlert}
               data-cy="request-rephrase-question"
-              disabled={!isCheckedIn || hasUnresolvedRephraseAlert}
+              disabled={!canRephrase}
             />
           </span>
         </Tooltip>

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -56,6 +56,10 @@ export default function TAQueueDetailButtons({
   );
   const { isCheckedIn, isHelping } = useTAInQueueInfo(queueId);
 
+  const rephraseTooltipTitle = hasUnresolvedRephraseAlert
+    ? "The student has already been asked to rephrase their question"
+    : "Ask the student to add more detail to their question";
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const sendRephraseAlert = async () => {
     const payload: RephraseQuestionPayload = {
@@ -179,18 +183,20 @@ export default function TAQueueDetailButtons({
         </Popconfirm>
         <Tooltip
           title={
-            hasUnresolvedRephraseAlert
-              ? "The student has already been asked to rephrase their question"
-              : "Ask the student to add more detail to their question"
+            isCheckedIn
+              ? rephraseTooltipTitle
+              : "You must check in to ask this student to rephrase their question"
           }
         >
-          <BannerOrangeButton
-            shape="circle"
-            icon={<QuestionOutlined />}
-            onClick={sendRephraseAlert}
-            data-cy="request-rephrase-question"
-            disabled={!isCheckedIn || hasUnresolvedRephraseAlert}
-          />
+          <span>
+            <BannerOrangeButton
+              shape="circle"
+              icon={<QuestionOutlined />}
+              onClick={sendRephraseAlert}
+              data-cy="request-rephrase-question"
+              disabled={!isCheckedIn || hasUnresolvedRephraseAlert}
+            />
+          </span>
         </Tooltip>
         <Tooltip title={helpTooltip}>
           <span>

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -3,6 +3,7 @@ import {
   CloseOutlined,
   DeleteOutlined,
   PhoneOutlined,
+  QuestionOutlined,
   UndoOutlined,
 } from "@ant-design/icons";
 import { API } from "@koh/api-client";
@@ -22,6 +23,7 @@ import { useQuestions } from "../../../hooks/useQuestions";
 import { useTAInQueueInfo } from "../../../hooks/useTAInQueueInfo";
 import {
   BannerDangerButton,
+  BannerOrangeButton,
   BannerPrimaryButton,
   CantFindButton,
   FinishHelpingButton,
@@ -171,7 +173,7 @@ export default function TAQueueDetailButtons({
             </span>
           </Tooltip>
         </Popconfirm>
-        {/* TODO: fix this <Tooltip title="Ask the student to add more detail to their question">
+        <Tooltip title="Ask the student to add more detail to their question">
           <BannerOrangeButton
             shape="circle"
             icon={<QuestionOutlined />}
@@ -179,7 +181,7 @@ export default function TAQueueDetailButtons({
             data-cy="request-rephrase-question"
             disabled={!isCheckedIn}
           />
-        </Tooltip> */}
+        </Tooltip>
         <Tooltip title={helpTooltip}>
           <span>
             <BannerPrimaryButton

--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -37,10 +37,12 @@ export default function TAQueueDetailButtons({
   courseId,
   queueId,
   question,
+  hasUnresolvedRephraseAlert,
 }: {
   courseId: number;
   queueId: number;
   question: Question;
+  hasUnresolvedRephraseAlert: boolean;
 }): ReactElement {
   const defaultMessage = useDefaultMessage();
   const { mutateQuestions } = useQuestions(queueId);
@@ -68,6 +70,8 @@ export default function TAQueueDetailButtons({
         payload,
         targetUserId: question.creator.id,
       });
+      await mutateQuestions();
+      message.success("Successfully asked student to rephrase their question.");
     } catch (e) {
       //If the ta creates an alert that already exists the error is caught and nothing happens
     }
@@ -173,13 +177,19 @@ export default function TAQueueDetailButtons({
             </span>
           </Tooltip>
         </Popconfirm>
-        <Tooltip title="Ask the student to add more detail to their question">
+        <Tooltip
+          title={
+            hasUnresolvedRephraseAlert
+              ? "The student has already been asked to rephrase their question"
+              : "Ask the student to add more detail to their question"
+          }
+        >
           <BannerOrangeButton
             shape="circle"
             icon={<QuestionOutlined />}
             onClick={sendRephraseAlert}
             data-cy="request-rephrase-question"
-            disabled={!isCheckedIn}
+            disabled={!isCheckedIn || hasUnresolvedRephraseAlert}
           />
         </Tooltip>
         <Tooltip title={helpTooltip}>

--- a/packages/app/components/Queue/TA/TAQueueDetailQuestion.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailQuestion.tsx
@@ -43,12 +43,14 @@ export default function TAQueueDetailQuestion({
   courseId,
   showName,
   showButtons,
+  hasUnresolvedRephraseAlert,
 }: {
   question: Question;
   queueId: number;
   courseId: number;
   showName?: boolean;
   showButtons?: boolean;
+  hasUnresolvedRephraseAlert: boolean;
 }) {
   return question.status === OpenQuestionStatus.Drafting ? (
     <StillDrafting>
@@ -79,6 +81,7 @@ export default function TAQueueDetailQuestion({
             courseId={courseId}
             queueId={queueId}
             question={question}
+            hasUnresolvedRephraseAlert={hasUnresolvedRephraseAlert}
           />
         )}
       </div>

--- a/packages/app/components/Queue/TA/TAQueueListDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueListDetail.tsx
@@ -102,9 +102,10 @@ export default function TAQueueListDetail({
   const selectedQuestion = allQuestionsList.find(
     (q) => q.id === selectedQuestionId
   );
-  const hasUnresolvedRephraseAlert = !questions?.unresolvedAlerts
+  const hasUnresolvedRephraseAlert = questions?.unresolvedAlerts
     ?.map((payload) => (payload as RephraseQuestionPayload).questionId)
     .includes(selectedQuestionId);
+  debugger;
   // set currentQuestion to null if it no longer exists in the queue
   if (selectedQuestionId && !selectedQuestion) {
     onSelectQuestion(null);

--- a/packages/app/components/Queue/TA/TAQueueListDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueListDetail.tsx
@@ -105,7 +105,6 @@ export default function TAQueueListDetail({
   const hasUnresolvedRephraseAlert = questions?.unresolvedAlerts
     ?.map((payload) => (payload as RephraseQuestionPayload).questionId)
     .includes(selectedQuestionId);
-  debugger;
   // set currentQuestion to null if it no longer exists in the queue
   if (selectedQuestionId && !selectedQuestion) {
     onSelectQuestion(null);

--- a/packages/app/components/Queue/TA/TAQueueListDetail.tsx
+++ b/packages/app/components/Queue/TA/TAQueueListDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftOutlined, QuestionCircleOutlined } from "@ant-design/icons";
-import { Question } from "@koh/common";
+import { Question, RephraseQuestionPayload } from "@koh/common";
 import { useWindowWidth } from "@react-hook/window-size";
 import { Button, Skeleton, Tooltip } from "antd";
 import Link from "next/link";
@@ -102,6 +102,9 @@ export default function TAQueueListDetail({
   const selectedQuestion = allQuestionsList.find(
     (q) => q.id === selectedQuestionId
   );
+  const hasUnresolvedRephraseAlert = !questions?.unresolvedAlerts
+    ?.map((payload) => (payload as RephraseQuestionPayload).questionId)
+    .includes(selectedQuestionId);
   // set currentQuestion to null if it no longer exists in the queue
   if (selectedQuestionId && !selectedQuestion) {
     onSelectQuestion(null);
@@ -189,6 +192,7 @@ export default function TAQueueListDetail({
           courseId={courseId}
           queueId={queueId}
           question={selectedQuestion}
+          hasUnresolvedRephraseAlert={hasUnresolvedRephraseAlert}
         />
       )}
       {isGrouping && (

--- a/packages/app/pages/course/[cid]/queue/[qid].tsx
+++ b/packages/app/pages/course/[cid]/queue/[qid].tsx
@@ -29,7 +29,7 @@ export default function Queue(): ReactElement {
         </Head>
         <NavBar courseId={Number(cid)} />
         {Role.STUDENT === role ? (
-          <StudentQueue qid={Number(qid)} />
+          <StudentQueue qid={Number(qid)} cid={Number(cid)} />
         ) : (
           <TAQueue qid={Number(qid)} courseId={Number(cid)} />
         )}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -912,6 +912,7 @@ export const ERROR_MESSAGES = {
   alertController: {
     duplicateAlert: "This alert has already been sent",
     notActiveAlert: "This is not an alert that's open for the current user",
+    incorrectPayload: "The payload provided was not of the correct type",
   },
   sseService: {
     getSubClient: "Unable to get the redis subscriber client",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -497,6 +497,9 @@ export class ListQuestionsResponse {
 
   @Type(() => QuestionGroup)
   groups!: Array<QuestionGroup>;
+
+  @Type(() => AlertPayload)
+  unresolvedAlerts?: Array<AlertPayload>;
 }
 
 export class GetQuestionResponse extends Question {}

--- a/packages/server/ormconfig.ts
+++ b/packages/server/ormconfig.ts
@@ -48,7 +48,10 @@ const typeorm = {
     ProfSectionGroupsModel,
   ],
   keepConnectionAlive: true,
-  logging: !!process.env.TYPEORM_LOGGING,
+  logging:
+    process.env.NODE_ENV !== 'production'
+      ? ['error']
+      : !!process.env.TYPEORM_LOGGING,
   ...(!!process.env.TYPEORM_CLI ? inCLI : {}),
 };
 module.exports = typeorm;

--- a/packages/server/src/alerts/alerts.controller.ts
+++ b/packages/server/src/alerts/alerts.controller.ts
@@ -53,6 +53,12 @@ export class AlertsController {
   ): Promise<CreateAlertResponse> {
     const { alertType, courseId, payload, targetUserId } = body;
 
+    if (!this.alertsService.assertPayloadType(alertType, payload)) {
+      throw new BadRequestException(
+        ERROR_MESSAGES.alertController.incorrectPayload,
+      );
+    }
+
     const anotherAlert = await AlertModel.findOne({
       where: {
         alertType,

--- a/packages/server/src/alerts/alerts.controller.ts
+++ b/packages/server/src/alerts/alerts.controller.ts
@@ -15,7 +15,6 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { pick } from 'lodash';
 import { JwtAuthGuard } from 'guards/jwt-auth.guard';
 import { User } from 'decorators/user.decorator';
 import { UserModel } from 'profile/user.entity';
@@ -33,16 +32,13 @@ export class AlertsController {
     @Param('courseId') courseId: number,
     @User() user: UserModel,
   ): Promise<GetAlertsResponse> {
-    const alerts = (
-      await AlertModel.find({
-        where: {
-          courseId,
-          user,
-          resolved: null,
-        },
-      })
-    ).map((alert) => pick(alert, ['sent', 'alertType', 'payload', 'id']));
-
+    const alerts = await AlertModel.find({
+      where: {
+        courseId,
+        user,
+        resolved: null,
+      },
+    });
     return { alerts: await this.alertsService.removeStaleAlerts(alerts) };
   }
 

--- a/packages/server/src/alerts/alerts.entity.ts
+++ b/packages/server/src/alerts/alerts.entity.ts
@@ -48,9 +48,10 @@ export class AlertModel extends BaseEntity {
   static unresolvedRephraseQuestionAlert(
     queueId: number,
   ): SelectQueryBuilder<AlertModel> {
+    const alertType = AlertType.REPHRASE_QUESTION;
     return this.createQueryBuilder('alert')
       .where('alert.resolved IS NULL')
-      .andWhere('alert.alertType::text = ' + AlertType.REPHRASE_QUESTION)
+      .andWhere('alert.alertType = :alertType', { alertType })
       .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {
         queueId,
       });

--- a/packages/server/src/alerts/alerts.entity.ts
+++ b/packages/server/src/alerts/alerts.entity.ts
@@ -7,7 +7,6 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
-  SelectQueryBuilder,
 } from 'typeorm';
 import { CourseModel } from '../course/course.entity';
 import { UserModel } from '../profile/user.entity';
@@ -44,16 +43,4 @@ export class AlertModel extends BaseEntity {
 
   @Column({ type: 'json' })
   payload: AlertPayload;
-
-  static unresolvedRephraseQuestionAlert(
-    queueId: number,
-  ): SelectQueryBuilder<AlertModel> {
-    const alertType = AlertType.REPHRASE_QUESTION;
-    return this.createQueryBuilder('alert')
-      .where('alert.resolved IS NULL')
-      .andWhere('alert.alertType = :alertType', { alertType })
-      .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {
-        queueId,
-      });
-  }
 }

--- a/packages/server/src/alerts/alerts.entity.ts
+++ b/packages/server/src/alerts/alerts.entity.ts
@@ -7,6 +7,7 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  SelectQueryBuilder,
 } from 'typeorm';
 import { CourseModel } from '../course/course.entity';
 import { UserModel } from '../profile/user.entity';
@@ -43,4 +44,15 @@ export class AlertModel extends BaseEntity {
 
   @Column({ type: 'json' })
   payload: AlertPayload;
+
+  static unresolvedRephraseQuestionAlert(
+    queueId: number,
+  ): SelectQueryBuilder<AlertModel> {
+    return this.createQueryBuilder('alert')
+      .where('alert.resolved IS NULL')
+      .andWhere('alert.alertType::text = ' + AlertType.REPHRASE_QUESTION)
+      .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {
+        queueId,
+      });
+  }
 }

--- a/packages/server/src/alerts/alerts.service.spec.ts
+++ b/packages/server/src/alerts/alerts.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Connection } from 'typeorm';
+import {
+  AlertFactory,
+  CourseFactory,
+  QuestionFactory,
+  QueueFactory,
+  TACourseFactory,
+} from '../../test/util/factories';
+import { TestTypeOrmModule } from '../../test/util/testUtils';
+import { AlertModel } from './alerts.entity';
+import { AlertsService } from './alerts.service';
+
+describe('Alerts service', () => {
+  let service: AlertsService;
+  let conn: Connection;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestTypeOrmModule],
+      providers: [AlertsService],
+    }).compile();
+
+    service = module.get<AlertsService>(AlertsService);
+    conn = module.get<Connection>(Connection);
+  });
+
+  afterAll(async () => {
+    await conn.close();
+  });
+
+  beforeEach(async () => {
+    await conn.synchronize(true);
+  });
+
+  describe('remove stale alerts', () => {
+    it('removes stale alerts', async () => {
+      const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({ course });
+
+      const queue = await QueueFactory.create({
+        course,
+        staffList: [ta.user],
+      });
+
+      const closedQuestion = await QuestionFactory.create({
+        createdAt: new Date(Date.now() - 90000),
+        closedAt: new Date(),
+        queue: queue,
+      });
+
+      const openQuestion = await QuestionFactory.create({
+        queue,
+      });
+
+      await AlertFactory.create({
+        user: closedQuestion.creator,
+        course: queue.course,
+        payload: {
+          questionId: closedQuestion.id,
+          queueId: queue.id,
+          courseId: queue.course.id,
+        },
+      });
+
+      const openAlert = await AlertFactory.create({
+        user: openQuestion.creator,
+        course: queue.course,
+        payload: {
+          questionId: openQuestion.id,
+          queueId: queue.id,
+          courseId: queue.course.id,
+        },
+      });
+
+      expect((await AlertModel.find()).length).toBe(2);
+
+      const nonStaleAlerts = await service.removeStaleAlerts(
+        await AlertModel.find({ where: { course: queue.course } }),
+      );
+
+      expect(nonStaleAlerts.length).toBe(1);
+      expect(nonStaleAlerts[0].id).toBe(openAlert.id);
+    });
+  });
+});

--- a/packages/server/src/alerts/alerts.service.spec.ts
+++ b/packages/server/src/alerts/alerts.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { TestTypeOrmModule } from '../../test/util/testUtils';
 import { AlertModel } from './alerts.entity';
 import { AlertsService } from './alerts.service';
+import { QueueModel } from '../queue/queue.entity';
 
 describe('Alerts service', () => {
   let service: AlertsService;
@@ -34,6 +35,38 @@ describe('Alerts service', () => {
     await conn.synchronize(true);
   });
 
+  async function createAlerts(queue: QueueModel): Promise<AlertModel> {
+    const closedQuestion = await QuestionFactory.create({
+      createdAt: new Date(Date.now() - 90000),
+      closedAt: new Date(),
+      queue: queue,
+    });
+
+    const openQuestion = await QuestionFactory.create({
+      queue,
+    });
+
+    await AlertFactory.create({
+      user: closedQuestion.creator,
+      course: queue.course,
+      payload: {
+        questionId: closedQuestion.id,
+        queueId: queue.id,
+        courseId: queue.course.id,
+      },
+    });
+
+    return await AlertFactory.create({
+      user: openQuestion.creator,
+      course: queue.course,
+      payload: {
+        questionId: openQuestion.id,
+        queueId: queue.id,
+        courseId: queue.course.id,
+      },
+    });
+  }
+
   describe('remove stale alerts', () => {
     it('removes stale alerts', async () => {
       const course = await CourseFactory.create();
@@ -44,37 +77,11 @@ describe('Alerts service', () => {
         staffList: [ta.user],
       });
 
-      const closedQuestion = await QuestionFactory.create({
-        createdAt: new Date(Date.now() - 90000),
-        closedAt: new Date(),
-        queue: queue,
-      });
+      const openAlert = await createAlerts(queue);
 
-      const openQuestion = await QuestionFactory.create({
-        queue,
-      });
-
-      await AlertFactory.create({
-        user: closedQuestion.creator,
-        course: queue.course,
-        payload: {
-          questionId: closedQuestion.id,
-          queueId: queue.id,
-          courseId: queue.course.id,
-        },
-      });
-
-      const openAlert = await AlertFactory.create({
-        user: openQuestion.creator,
-        course: queue.course,
-        payload: {
-          questionId: openQuestion.id,
-          queueId: queue.id,
-          courseId: queue.course.id,
-        },
-      });
-
-      expect((await AlertModel.find()).length).toBe(2);
+      expect(
+        (await AlertModel.find({ where: { course: queue.course } })).length,
+      ).toBe(2);
 
       const nonStaleAlerts = await service.removeStaleAlerts(
         await AlertModel.find({ where: { course: queue.course } }),
@@ -119,6 +126,31 @@ describe('Alerts service', () => {
           questionId: 420,
         }),
       ).toBeFalsy();
+    });
+  });
+
+  describe('getting unresolved alerts for the rephrase question type', () => {
+    it('gets unresolved alerts', async () => {
+      const course = await CourseFactory.create();
+      const ta = await TACourseFactory.create({ course });
+      const queue = await QueueFactory.create({
+        course,
+        staffList: [ta.user],
+      });
+      const openAlert = await createAlerts(queue);
+      await service.removeStaleAlerts(
+        await AlertModel.find({ where: { course: queue.course } }),
+      );
+
+      const unresolvedAlerts = await service.getUnresolvedRephraseQuestionAlert(
+        queue.id,
+      );
+
+      expect(unresolvedAlerts.length).toBe(1);
+      expect(unresolvedAlerts[0].id).toBe(openAlert.id);
+      expect(unresolvedAlerts[0].resolved).toBeNull();
+      expect(unresolvedAlerts[0].alertType).toBe(AlertType.REPHRASE_QUESTION);
+      expect(unresolvedAlerts[0].payload['queueId']).toBe(queue.id);
     });
   });
 });

--- a/packages/server/src/alerts/alerts.service.spec.ts
+++ b/packages/server/src/alerts/alerts.service.spec.ts
@@ -1,3 +1,4 @@
+import { AlertType } from '@koh/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Connection } from 'typeorm';
 import {
@@ -81,6 +82,43 @@ describe('Alerts service', () => {
 
       expect(nonStaleAlerts.length).toBe(1);
       expect(nonStaleAlerts[0].id).toBe(openAlert.id);
+    });
+  });
+
+  describe('check payload type', () => {
+    it('correct rephrase question payloads pass', () => {
+      expect(
+        service.assertPayloadType(AlertType.REPHRASE_QUESTION, {
+          courseId: 2,
+          queueId: 1,
+          questionId: 420,
+        }),
+      ).toBeTruthy();
+    });
+
+    it('incorrect rephrase question payloads fail', () => {
+      expect(
+        service.assertPayloadType(AlertType.REPHRASE_QUESTION, {
+          courseId: 'PYHUGYHIF',
+          queueId: 1,
+          questionId: 420,
+        }),
+      ).toBeFalsy();
+
+      expect(
+        service.assertPayloadType(AlertType.REPHRASE_QUESTION, {
+          courseId: 69,
+          questionId: 420,
+        }),
+      ).toBeFalsy();
+
+      expect(
+        service.assertPayloadType(AlertType.REPHRASE_QUESTION, {
+          courseId: 69,
+          queueId: '12',
+          questionId: 420,
+        }),
+      ).toBeFalsy();
     });
   });
 });

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -24,6 +24,7 @@ export class AlertsService {
             console.log(`Rephrase Question alert with id ${alert.id} expired`);
             if (!question.closedAt) {
               question.closedAt = new Date();
+              await question.save();
             }
           } else {
             nonStaleAlerts.push(alert);

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -3,12 +3,13 @@ import { Injectable } from '@nestjs/common';
 import { QuestionModel } from 'question/question.entity';
 import { Connection } from 'typeorm';
 import { QueueModel } from '../queue/queue.entity';
+import { AlertModel } from './alerts.entity';
 
 @Injectable()
 export class AlertsService {
   constructor(private connection: Connection) {}
 
-  async removeStaleAlerts(alerts: Alert[]): Promise<Alert[]> {
+  async removeStaleAlerts(alerts: AlertModel[]): Promise<Alert[]> {
     const nonStaleAlerts = [];
 
     for (const alert of alerts) {
@@ -20,12 +21,19 @@ export class AlertsService {
           const question = await QuestionModel.findOne(payload.questionId);
 
           const queue = await QueueModel.findOne(payload.queueId);
-          if (question.closedAt || !(await queue.checkIsOpen())) {
-            console.log(`Rephrase Question alert with id ${alert.id} expired`);
+          const isQueueOpen = await queue.checkIsOpen();
+          if (question.closedAt || !isQueueOpen) {
+            console.log(
+              `Rephrase Question alert with id ${
+                alert.id
+              } expired ${isQueueOpen} ${JSON.stringify(question)}`,
+            );
             if (!question.closedAt) {
               question.closedAt = new Date();
               await question.save();
             }
+            alert.resolved = new Date();
+            await alert.save();
           } else {
             nonStaleAlerts.push(alert);
           }

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -21,7 +21,7 @@ export class AlertsService {
           const question = await QuestionModel.findOne(payload.questionId);
 
           const queue = await QueueModel.findOne(payload.queueId);
-          const isQueueOpen = await queue.checkIsOpen();
+          const isQueueOpen = await queue?.checkIsOpen();
           if (question.closedAt || !isQueueOpen) {
             console.log(
               `Rephrase Question alert with id ${

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -31,11 +31,6 @@ export class AlertsService {
           });
           const isQueueOpen = await queue?.checkIsOpen();
           if (question.closedAt || !isQueueOpen) {
-            console.log(
-              `Rephrase Question alert with id ${
-                alert.id
-              } expired ${isQueueOpen} ${JSON.stringify(question)}`,
-            );
             if (!question.closedAt) {
               question.closedAt = new Date();
               await question.save();

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -1,4 +1,9 @@
-import { Alert, AlertType, RephraseQuestionPayload } from '@koh/common';
+import {
+  Alert,
+  AlertPayload,
+  AlertType,
+  RephraseQuestionPayload,
+} from '@koh/common';
 import { Injectable } from '@nestjs/common';
 import { QuestionModel } from 'question/question.entity';
 import { Connection } from 'typeorm';
@@ -37,9 +42,26 @@ export class AlertsService {
           } else {
             nonStaleAlerts.push(alert);
           }
+          break;
       }
     }
 
     return nonStaleAlerts;
+  }
+
+  assertPayloadType(alertType: AlertType, payload: AlertPayload): boolean {
+    switch (alertType) {
+      case AlertType.REPHRASE_QUESTION:
+        const castPayload = payload as RephraseQuestionPayload;
+
+        return (
+          !!castPayload.courseId &&
+          !!castPayload.questionId &&
+          !!castPayload.queueId &&
+          typeof castPayload.courseId === 'number' &&
+          typeof castPayload.questionId === 'number' &&
+          typeof castPayload.queueId === 'number'
+        );
+    }
   }
 }

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -69,4 +69,17 @@ export class AlertsService {
         );
     }
   }
+
+  async getUnresolvedRephraseQuestionAlert(
+    queueId: number,
+  ): Promise<AlertModel[]> {
+    const alertType = AlertType.REPHRASE_QUESTION;
+    return await AlertModel.createQueryBuilder('alert')
+      .where('alert.resolved IS NULL')
+      .andWhere('alert.alertType = :alertType', { alertType })
+      .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {
+        queueId,
+      })
+      .getMany();
+  }
 }

--- a/packages/server/src/queue/__snapshots__/queue.service.spec.ts.snap
+++ b/packages/server/src/queue/__snapshots__/queue.service.spec.ts.snap
@@ -45,6 +45,7 @@ ListQuestionsResponse {
       "text": "help someone else",
     },
   ],
+  "unresolvedAlerts": Array [],
   "yourQuestion": QuestionModel {
     "closedAt": null,
     "createdAt": 2020-11-02T12:00:00.000Z,

--- a/packages/server/src/queue/queue.module.ts
+++ b/packages/server/src/queue/queue.module.ts
@@ -5,6 +5,8 @@ import { SSEModule } from 'sse/sse.module';
 import { QueueService } from './queue.service';
 import { QueueSSEService } from './queue-sse.service';
 import { QueueSubscriber } from './queue.subscriber';
+import { AlertsService } from '../alerts/alerts.service';
+import { AlertsModule } from '../alerts/alerts.module';
 
 @Module({
   controllers: [QueueController],
@@ -13,8 +15,9 @@ import { QueueSubscriber } from './queue.subscriber';
     QueueService,
     QueueSSEService,
     QueueSubscriber,
+    AlertsService,
   ],
   exports: [QueueCleanService, QueueSSEService],
-  imports: [SSEModule],
+  imports: [SSEModule, AlertsModule],
 })
 export class QueueModule {}

--- a/packages/server/src/queue/queue.service.spec.ts
+++ b/packages/server/src/queue/queue.service.spec.ts
@@ -12,6 +12,7 @@ import {
 import { TestConfigModule, TestTypeOrmModule } from '../../test/util/testUtils';
 import { QueueModel } from './queue.entity';
 import { QueueService } from './queue.service';
+import { AlertsService } from '../alerts/alerts.service';
 
 describe('QueueService', () => {
   let service: QueueService;
@@ -21,7 +22,7 @@ describe('QueueService', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [TestTypeOrmModule, TestConfigModule],
-      providers: [QueueService],
+      providers: [QueueService, AlertsService],
     }).compile();
 
     service = module.get<QueueService>(QueueService);

--- a/packages/server/src/queue/queue.service.spec.ts
+++ b/packages/server/src/queue/queue.service.spec.ts
@@ -73,6 +73,7 @@ describe('QueueService', () => {
         questionsGettingHelp: ['Helping'],
         queue: ['Queued', 'Drafting'],
         groups: [],
+        unresolvedAlerts: [],
       });
     });
 

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -14,7 +14,7 @@ import { pick } from 'lodash';
 import { QuestionModel } from 'question/question.entity';
 import { Connection, In } from 'typeorm';
 import { QueueModel } from './queue.entity';
-import { AlertModel } from '../alerts/alerts.entity';
+import { AlertsService } from '../alerts/alerts.service';
 
 /**
  * Get data in service of the queue controller and SSE
@@ -22,7 +22,10 @@ import { AlertModel } from '../alerts/alerts.entity';
  */
 @Injectable()
 export class QueueService {
-  constructor(private connection: Connection) {}
+  constructor(
+    private connection: Connection,
+    private alertsService: AlertsService,
+  ) {}
 
   async getQueue(queueId: number): Promise<QueueModel> {
     const queue = await QueueModel.findOne(queueId, {
@@ -56,7 +59,7 @@ export class QueueService {
       .getMany();
 
     const unresolvedRephraseQuestionAlerts =
-      await AlertModel.unresolvedRephraseQuestionAlert(queueId).getMany();
+      await this.alertsService.getUnresolvedRephraseQuestionAlert(queueId);
 
     const groupMap: Record<number, QuestionGroup> = {};
 

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -14,6 +14,7 @@ import { pick } from 'lodash';
 import { QuestionModel } from 'question/question.entity';
 import { Connection, In } from 'typeorm';
 import { QueueModel } from './queue.entity';
+import { AlertModel } from '../alerts/alerts.entity';
 
 /**
  * Get data in service of the queue controller and SSE
@@ -54,6 +55,9 @@ export class QueueService {
       .leftJoinAndSelect('question.taHelped', 'taHelped')
       .getMany();
 
+    const unresolvedRephraseQuestionAlerts =
+      await AlertModel.unresolvedRephraseQuestionAlert(queueId).getMany();
+
     const groupMap: Record<number, QuestionGroup> = {};
 
     questionsFromDb.forEach((question) => {
@@ -86,6 +90,10 @@ export class QueueService {
     );
 
     questions.groups = Object.values(groupMap);
+
+    questions.unresolvedAlerts = unresolvedRephraseQuestionAlerts.map(
+      (alert) => alert.payload,
+    );
 
     return questions;
   }

--- a/packages/server/test/__snapshots__/queue.integration.ts.snap
+++ b/packages/server/test/__snapshots__/queue.integration.ts.snap
@@ -31,5 +31,6 @@ Object {
       "text": "in queue",
     },
   ],
+  "unresolvedAlerts": Array [],
 }
 `;

--- a/packages/server/test/alerts.integration.ts
+++ b/packages/server/test/alerts.integration.ts
@@ -1,0 +1,109 @@
+import { AlertsModule } from 'alerts/alerts.module';
+import {
+  AlertFactory,
+  CourseFactory,
+  QuestionFactory,
+  QueueFactory,
+  UserCourseFactory,
+  UserFactory,
+} from './util/factories';
+import { setupIntegrationTest } from './util/testUtils';
+
+describe('Alerts Integration', () => {
+  const supertest = setupIntegrationTest(AlertsModule);
+
+  describe('GET /alerts', () => {
+    it('returns whatever alerts are in the db for this course and user', async () => {
+      const course1 = await CourseFactory.create();
+      const course2 = await CourseFactory.create();
+
+      const queue1 = await QueueFactory.create({
+        course: course1,
+      });
+      const question1 = await QuestionFactory.create({
+        queue: queue1,
+      });
+
+      const queue2 = await QueueFactory.create({
+        course: course2,
+      });
+      const question2 = await QuestionFactory.create({
+        queue: queue2,
+      });
+
+      const user1 = await UserFactory.create();
+      const user2 = await UserFactory.create();
+      await UserCourseFactory.create({
+        user: user1,
+        course: course1,
+      });
+
+      await UserCourseFactory.create({
+        user: user2,
+        course: course1,
+      });
+      await UserCourseFactory.create({
+        user: user1,
+        course: course2,
+      });
+
+      const alert1 = await AlertFactory.create({
+        user: user1,
+        course: course1,
+        payload: {
+          questionId: question1.id,
+          queueId: queue1.id,
+          courseId: course1.id,
+        },
+      });
+
+      const alert2 = await AlertFactory.create({
+        user: user1,
+        course: course2,
+        payload: {
+          questionId: question2.id,
+          queueId: queue2.id,
+          courseId: course2.id,
+        },
+      });
+
+      let res = await supertest({ userId: user1.id })
+        .get(`/alerts/${course1.id}`)
+        .expect(200);
+
+      expect(res.body.alerts).toStrictEqual([
+        {
+          alertType: 'rephraseQuestion',
+          id: alert1.id,
+          payload: {
+            questionId: question1.id,
+            queueId: queue1.id,
+            courseId: course1.id,
+          },
+          sent: alert1.sent.toISOString(),
+        },
+      ]);
+
+      res = await supertest({ userId: user2.id })
+        .get(`/alerts/${course1.id}`)
+        .expect(200);
+      expect(res.body.alerts.length).toBe(0);
+
+      res = await supertest({ userId: user1.id })
+        .get(`/alerts/${course2.id}`)
+        .expect(200);
+      expect(res.body.alerts).toStrictEqual([
+        {
+          alertType: 'rephraseQuestion',
+          id: alert2.id,
+          payload: {
+            questionId: question2.id,
+            queueId: queue2.id,
+            courseId: course2.id,
+          },
+          sent: alert2.sent.toISOString(),
+        },
+      ]);
+    });
+  });
+});

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -1,5 +1,6 @@
-import { QuestionType, Role } from '@koh/common';
 import { QuestionGroupModel } from 'question/question-group.entity';
+import { AlertType, QuestionType, Role } from '@koh/common';
+import { AlertModel } from 'alerts/alerts.entity';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { Factory } from 'typeorm-factory';
 import { CourseModel } from '../../src/course/course.entity';
@@ -96,3 +97,9 @@ export const LastRegistrationFactory = new Factory(LastRegistrationModel)
 export const ProfSectionGroupsFactory = new Factory(ProfSectionGroupsModel)
   .assocOne('prof', UserFactory)
   .attr('sectionGroups', []);
+export const AlertFactory = new Factory(AlertModel)
+  .attr('alertType', AlertType.REPHRASE_QUESTION)
+  .attr('sent', new Date(Date.now() - 86400000))
+  .assocOne('user', UserFactory)
+  .assocOne('course', CourseFactory)
+  .attr('payload', {});


### PR DESCRIPTION
# Description
Fixing the alerts/rephrase question flow that never got merged in before. Should allow TAs/Profs to ask students to rephrase their question multiple times. Note: the rephrase tooltip is not displayed for grouped questions cause they're grouped xd.

![alerts](https://user-images.githubusercontent.com/23366632/154775049-33ae87e8-b879-4bd0-9c3f-758d8a6d1135.gif)

Closes #803 
Closes https://github.com/sandboxnu/office-hours/issues/661

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] With the power of manual testing


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
