### PR TITLE
Remove nullability from sectionGroupName

### DIFF
--- a/packages/server/migration/1645995817187-section_group_name_null.ts
+++ b/packages/server/migration/1645995817187-section_group_name_null.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class sectionGroupNameNull1645995817187 implements MigrationInterface {
+  name = 'sectionGroupNameNull1645995817187';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "course_model" ALTER COLUMN "sectionGroupName" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "course_model" ALTER COLUMN "sectionGroupName" DROP NOT NULL`,
+    );
+  }
+}

--- a/packages/server/src/course/course.entity.ts
+++ b/packages/server/src/course/course.entity.ts
@@ -30,7 +30,7 @@ export class CourseModel extends BaseEntity {
   @Column('text')
   name: string; // display name entered by Prof
 
-  @Column('text', { nullable: true }) // nullable for backwards compatibility
+  @Column('text') // nullable for backwards compatibility
   sectionGroupName: string; // from admin
 
   @Column('text', { nullable: true })

--- a/packages/server/src/course/course.entity.ts
+++ b/packages/server/src/course/course.entity.ts
@@ -30,7 +30,7 @@ export class CourseModel extends BaseEntity {
   @Column('text')
   name: string; // display name entered by Prof
 
-  @Column('text') // nullable for backwards compatibility
+  @Column('text')
   sectionGroupName: string; // from admin
 
   @Column('text', { nullable: true })

--- a/packages/server/test/__snapshots__/course.integration.ts.snap
+++ b/packages/server/test/__snapshots__/course.integration.ts.snap
@@ -16,7 +16,7 @@ Object {
     },
   ],
   "queues": Array [],
-  "sectionGroupName": null,
+  "sectionGroupName": "CS 2500",
   "selfEnroll": false,
   "timezone": "America/New_York",
 }

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -46,6 +46,7 @@ export const OfficeHourFactory = new Factory(OfficeHourModel)
 
 export const CourseFactory = new Factory(CourseModel)
   .attr('name', 'CS 2500')
+  .attr('sectionGroupName', 'CS 2500')
   .attr('icalURL', 'http://hi.com')
   .attr('enabled', true)
   .assocOne('semester', SemesterFactory)


### PR DESCRIPTION
# Description

Don't allow sectionGroupName column in Course Entity to be null

(sectionGroupName has been backfilled)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Not sure how to test this, would I have to generate + run migrations on dev?**

**Update: generated + ran migration on dev and dev ran successfully, new tests also ran successfully after updated snapshot**

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
