### PR TITLE
toggling through more than 75 values

### DIFF
--- a/packages/server/src/insights/insight-objects.ts
+++ b/packages/server/src/insights/insight-objects.ts
@@ -133,7 +133,6 @@ export const MostActiveStudents: InsightObject = {
       .addGroupBy('name')
       .addGroupBy('"UserModel".email')
       .orderBy('4', 'DESC')
-      .limit(75)
       .getRawMany();
 
     return {

--- a/packages/server/src/insights/insight-objects.ts
+++ b/packages/server/src/insights/insight-objects.ts
@@ -104,7 +104,7 @@ export const TotalQuestionsAsked: InsightObject = {
 export const MostActiveStudents: InsightObject = {
   displayName: 'Most Active Students',
   description:
-    'Who are the students who have asked the most questions in Office Hours? (limit 75)',
+    'Who are the students who have asked the most questions in Office Hours?',
   roles: [Role.PROFESSOR],
   component: InsightComponent.SimpleTable,
   size: 'default' as const,


### PR DESCRIPTION
# Description

Remove limit from query that gets how many questions each student asked

Allow professor to view more than 75 data values

Closes #844

## Type of change

<img width="629" alt="Screen Shot 2022-03-03 at 6 46 55 PM" src="https://user-images.githubusercontent.com/39414740/156672305-f606aaf7-a4f8-4d6c-9124-ad6aed620da8.png">

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran in dev, added a bunch of questions to the queue, and checked to see if table functioned

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
