### PR TITLE
Fix clean alerts

### DIFF
--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -31,10 +31,6 @@ export class AlertsService {
           });
           const isQueueOpen = await queue?.checkIsOpen();
           if (question.closedAt || !isQueueOpen) {
-            if (!question.closedAt) {
-              question.closedAt = new Date();
-              await question.save();
-            }
             alert.resolved = new Date();
             await alert.save();
           } else {


### PR DESCRIPTION
# Description

Essentially, there was a bug that I didn't really catch when finishing up the alerts flow in my other pr. The bug was that some alerts were never resolved after a queue closes at midnight, so the solution here is resolving those alerts during queue clean up cron job.

Closes #855

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] my singular unit test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
