### PR TITLE
Retrieve user info for professors endpoint

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -30,6 +30,7 @@ import {
   UpdateQuestionResponse,
   UpdateQueueParams,
   UserPartial,
+  Role,
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -78,8 +79,17 @@ class APIClient {
   course = {
     get: async (courseId: number) =>
       this.req("GET", `/api/v1/courses/${courseId}`, GetCourseResponse),
-    getUserInfo: async (courseId: number, page: number, search: string) =>
-      this.req("GET", `/api/v1/courses/${courseId}/getUserInfo/${page}/${search}`, UserPartial),
+    getUserInfo: async (
+      courseId: number,
+      page: number,
+      search: string,
+      role: Role
+    ) =>
+      this.req(
+        "GET",
+        `/api/v1/courses/${courseId}/get_user_info/${role}/${page}/${search}`,
+        UserPartial
+      ),
     updateCalendar: async (courseId: number) =>
       this.req("POST", `/api/v1/courses/${courseId}/update_calendar`),
     getCourseOverrides: async (courseId: number) =>

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -29,6 +29,7 @@ import {
   UpdateQuestionParams,
   UpdateQuestionResponse,
   UpdateQueueParams,
+  UserPartial,
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -77,6 +78,8 @@ class APIClient {
   course = {
     get: async (courseId: number) =>
       this.req("GET", `/api/v1/courses/${courseId}`, GetCourseResponse),
+    getUserInfo: async (courseId: number, page: number, search: string) =>
+      this.req("GET", `/api/v1/courses/${courseId}/getUserInfo/${page}/${search}`, UserPartial),
     updateCalendar: async (courseId: number) =>
       this.req("POST", `/api/v1/courses/${courseId}/update_calendar`),
     getCourseOverrides: async (courseId: number) =>

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -83,7 +83,7 @@ class APIClient {
       courseId: number,
       page: number,
       search: string,
-      role: Role
+      role?: Role
     ) =>
       this.req(
         "GET",

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -82,13 +82,14 @@ class APIClient {
     getUserInfo: async (
       courseId: number,
       page: number,
-      search: string,
-      role?: Role
+      role?: Role,
+      search?: string
     ) =>
       this.req(
         "GET",
-        `/api/v1/courses/${courseId}/get_user_info/${role}/${page}/${search}`,
-        UserPartial
+        `/api/v1/courses/${courseId}/get_user_info/${page}/${role}`,
+        UserPartial,
+        { search }
       ),
     updateCalendar: async (courseId: number) =>
       this.req("POST", `/api/v1/courses/${courseId}/update_calendar`),

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -804,6 +804,9 @@ export type DateRangeType = {
 };
 
 export const ERROR_MESSAGES = {
+  common: {
+    pageOutOfBounds: "Can't retrieve out of bounds page.",
+  },
   courseController: {
     checkIn: {
       cannotCreateNewQueueIfNotProfessor:

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -557,17 +557,33 @@ export class CourseController {
     }
   }
 
-  @Get(':id/get_user_info/:page/:search')
-  @UseGuards(JwtAuthGuard, CourseRolesGuard)
-  @Roles(Role.PROFESSOR)
+  @Get(':id/get_user_info/:role/:page/:search')
+  // @UseGuards(JwtAuthGuard, CourseRolesGuard)
+  // @Roles(Role.PROFESSOR)
   async getUserInfo(
     @Param('id') courseId: number,
     @Param('page') page: number,
     @Param('search') search: string,
-    @Param('role') role: Role,
+    @Param('role') role?: Role,
   ): Promise<UserPartial> {
     try {
-      return { id: courseId + page, name: search, email: role, photoURL: '' };
+      const users = await UserCourseModel.createQueryBuilder()
+        .innerJoin(
+          UserModel,
+          'UserModel',
+          '"UserModel".id = "UserCourseModel"."userId"',
+        )
+        .where('"UserCourseModel"."courseId" = :courseId', { courseId })
+        .andWhere('"UserCourseModel".role = :role', { role })
+        .getMany();
+      console.log('USERS');
+      console.log(users);
+      console.log('USERS');
+      console.log(users);
+      return {
+        id: page,
+        name: search,
+      };
     } catch (err) {
       console.error(err);
       throw new HttpException(

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -596,12 +596,15 @@ export class CourseController {
     @Query('search') search?: string,
   ): Promise<UserPartial[]> {
     const pageSize = 50;
+    if (!search) {
+      search = '';
+    }
     const users = await this.courseService.getUserInfo(
       courseId,
       page,
       pageSize,
-      role,
       search,
+      role,
     );
     return users;
   }

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -596,22 +596,14 @@ export class CourseController {
     @Query('search') search?: string,
   ): Promise<UserPartial[]> {
     const pageSize = 50;
-    try {
-      const users = await this.courseService.getUserInfo(
-        courseId,
-        page,
-        pageSize,
-        role,
-        search,
-      );
-      return users;
-    } catch (err) {
-      console.error(err);
-      throw new HttpException(
-        ERROR_MESSAGES.common.pageOutOfBounds,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
+    const users = await this.courseService.getUserInfo(
+      courseId,
+      page,
+      pageSize,
+      role,
+      search,
+    );
+    return users;
   }
 
   @Post(':id/self_enroll')

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -32,7 +32,7 @@ import async from 'async';
 import moment = require('moment');
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { UserCourseModel } from 'profile/user-course.entity';
-import { Connection, getRepository, MoreThanOrEqual } from 'typeorm';
+import { Brackets, Connection, getRepository, MoreThanOrEqual } from 'typeorm';
 import { Roles } from '../decorators/roles.decorator';
 import { User, UserId } from '../decorators/user.decorator';
 import { CourseRolesGuard } from '../guards/course-roles.guard';
@@ -557,33 +557,61 @@ export class CourseController {
     }
   }
 
-  @Get(':id/get_user_info/:role/:page/:search')
-  // @UseGuards(JwtAuthGuard, CourseRolesGuard)
-  // @Roles(Role.PROFESSOR)
+  @Get(':id/get_user_info/:page/:role?')
+  @UseGuards(JwtAuthGuard, CourseRolesGuard)
+  @Roles(Role.PROFESSOR)
   async getUserInfo(
     @Param('id') courseId: number,
     @Param('page') page: number,
-    @Param('search') search: string,
     @Param('role') role?: Role,
-  ): Promise<UserPartial> {
+    @Query('search') search?: string,
+  ): Promise<UserPartial[]> {
     try {
-      const users = await UserCourseModel.createQueryBuilder()
-        .innerJoin(
-          UserModel,
-          'UserModel',
+      const query = await getRepository(UserModel)
+        .createQueryBuilder()
+        .leftJoin(
+          UserCourseModel,
+          'UserCourseModel',
           '"UserModel".id = "UserCourseModel"."userId"',
         )
-        .where('"UserCourseModel"."courseId" = :courseId', { courseId })
-        .andWhere('"UserCourseModel".role = :role', { role })
+        .where('"UserCourseModel"."courseId" = :courseId', { courseId });
+
+      // check if searching for specific role
+      if (role) {
+        query.andWhere('"UserCourseModel".role = :role', { role });
+      }
+      // check if searching for specific name
+      if (search) {
+        const likeSearch = `%${search}%`.toUpperCase();
+        query.andWhere(
+          new Brackets((q) => {
+            q.where('UPPER("UserModel"."firstName") like :firstSearch', {
+              firstSearch: likeSearch,
+            }).orWhere('UPPER("UserModel"."lastName") like :lastSearch', {
+              lastSearch: likeSearch,
+            });
+          }),
+        );
+      }
+
+      // page size constants, should prob move this to index or utils or something
+      const PAGE_SIZE = 50;
+
+      // run query
+      const users = query
+        .select([
+          'UserModel.id',
+          'UserModel.firstName',
+          'UserModel.lastName',
+          'UserModel.photoURL',
+          'UserModel.email',
+        ])
+        .orderBy('UserModel.firstName')
+        .skip((page - 1) * PAGE_SIZE)
+        .take(PAGE_SIZE)
         .getMany();
-      console.log('USERS');
-      console.log(users);
-      console.log('USERS');
-      console.log(users);
-      return {
-        id: page,
-        name: search,
-      };
+
+      return users;
     } catch (err) {
       console.error(err);
       throw new HttpException(

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -9,6 +9,7 @@ import {
   TACheckoutResponse,
   UpdateCourseOverrideBody,
   UpdateCourseOverrideResponse,
+  UserPartial,
 } from '@koh/common';
 import {
   BadRequestException,
@@ -551,6 +552,26 @@ export class CourseController {
       console.error(err);
       throw new HttpException(
         ERROR_MESSAGES.courseController.checkInTime,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  @Get(':id/get_user_info/:page/:search')
+  @UseGuards(JwtAuthGuard, CourseRolesGuard)
+  @Roles(Role.PROFESSOR)
+  async getUserInfo(
+    @Param('id') courseId: number,
+    @Param('page') page: number,
+    @Param('search') search: string,
+    @Param('role') role: Role,
+  ): Promise<UserPartial> {
+    try {
+      return { id: courseId + page, name: search, email: role, photoURL: '' };
+    } catch (err) {
+      console.error(err);
+      throw new HttpException(
+        ERROR_MESSAGES.common.pageOutOfBounds,
         HttpStatus.BAD_REQUEST,
       );
     }

--- a/packages/server/src/course/course.service.spec.ts
+++ b/packages/server/src/course/course.service.spec.ts
@@ -10,6 +10,7 @@ import { CourseService } from './course.service';
 import { UserModel } from 'profile/user.entity';
 import { CourseModel } from './course.entity';
 import { Role } from '@koh/common';
+import { LoginCourseService } from 'login/login-course.service';
 
 describe('CourseService', () => {
   let service: CourseService;
@@ -19,7 +20,7 @@ describe('CourseService', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [TestTypeOrmModule, TestConfigModule],
-      providers: [CourseService],
+      providers: [CourseService, LoginCourseService],
     }).compile();
 
     service = module.get<CourseService>(CourseService);

--- a/packages/server/src/course/course.service.spec.ts
+++ b/packages/server/src/course/course.service.spec.ts
@@ -105,6 +105,8 @@ describe('CourseService', () => {
         firstName: 'Tingwei',
         lastName: 'Shi',
         email: 'tshi@northeastern.edu',
+        photoURL:
+          'https://files.slack.com/files-pri/TE565NU79-F02K81U7S13/image_from_ios.jpg',
       });
       await UserCourseFactory.create({
         user: tingwei,
@@ -280,14 +282,16 @@ describe('CourseService', () => {
     });
 
     it('returns name, email, and photoURL for user', async () => {
-      const courseId = 2;
-      const role = Role.TA;
+      const courseId = 1;
+      search = 'tingwei';
       const user = (
-        await service.getUserInfo(courseId, page, pageSize, search, role)
+        await service.getUserInfo(courseId, page, pageSize, search)
       )[0] as UserPartial;
-      expect(user.name).toEqual('Vera Kong');
-      expect(user.email).toEqual('vkong@northeastern.edu');
-      expect(user.photoURL).toEqual('photo@url.com');
+      expect(user.name).toEqual('Tingwei Shi');
+      expect(user.email).toEqual('tshi@northeastern.edu');
+      expect(user.photoURL).toEqual(
+        'https://files.slack.com/files-pri/TE565NU79-F02K81U7S13/image_from_ios.jpg',
+      );
     });
 
     it('returns danish when search term is danish', async () => {

--- a/packages/server/src/course/course.service.spec.ts
+++ b/packages/server/src/course/course.service.spec.ts
@@ -1,0 +1,180 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import { Connection } from 'typeorm';
+import {
+  UserFactory,
+  UserCourseFactory,
+  CourseFactory,
+} from '../../test/util/factories';
+import { TestTypeOrmModule, TestConfigModule } from '../../test/util/testUtils';
+import { CourseService } from './course.service';
+import { UserModel } from 'profile/user.entity';
+import { CourseModel } from './course.entity';
+import { Role } from '@koh/common';
+
+describe('CourseService', () => {
+  let service: CourseService;
+
+  let conn: Connection;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestTypeOrmModule, TestConfigModule],
+      providers: [CourseService],
+    }).compile();
+
+    service = module.get<CourseService>(CourseService);
+    conn = module.get<Connection>(Connection);
+  });
+
+  afterAll(async () => {
+    await conn.close();
+  });
+
+  beforeEach(async () => {
+    await conn.synchronize(true);
+  });
+
+  describe('getUserInfo', () => {
+    let profDanish: UserModel;
+    let profIris: UserModel;
+    let vera: UserModel;
+    let tingwei: UserModel;
+    let neel: UserModel;
+    let sumit: UserModel;
+    let angela: UserModel;
+    let fundies1: CourseModel;
+    let algo: CourseModel;
+    // page defaults
+    const page = 1;
+    const pageSize = 10;
+    beforeEach(async () => {
+      // Initialize courses
+      fundies1 = await CourseFactory.create({
+        name: 'Fundies 1',
+      });
+      algo = await CourseFactory.create({
+        name: 'Algo',
+      });
+      // Initialize Danish as professor in both courses
+      profDanish = await UserFactory.create({
+        firstName: 'Danish',
+        lastName: 'Farooq',
+        email: 'dfarooq@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: profDanish,
+        course: fundies1,
+        role: Role.PROFESSOR,
+      });
+      await UserCourseFactory.create({
+        user: profDanish,
+        course: algo,
+        role: Role.PROFESSOR,
+      });
+      // Initialize Iris as professor in only fundies
+      profIris = await UserFactory.create({
+        firstName: 'Iris',
+        lastName: 'Liu',
+        email: 'iliu@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: profIris,
+        course: fundies1,
+        role: Role.PROFESSOR,
+      });
+      // Initialize Vera as TA in both courses
+      vera = await UserFactory.create({
+        firstName: 'Vera',
+        lastName: 'Kong',
+        email: 'vkong@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: vera,
+        course: fundies1,
+        role: Role.TA,
+      });
+      await UserCourseFactory.create({
+        user: vera,
+        course: algo,
+        role: Role.TA,
+      });
+      // Initialize Tingwei as TA in fundies and student in algo
+      tingwei = await UserFactory.create({
+        firstName: 'Tingwei',
+        lastName: 'Shi',
+        email: 'tshi@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: tingwei,
+        course: fundies1,
+        role: Role.TA,
+      });
+      await UserCourseFactory.create({
+        user: tingwei,
+        course: algo,
+        role: Role.STUDENT,
+      });
+      // Initialize Neel as TA in fundies and not in algo
+      neel = await UserFactory.create({
+        firstName: 'Neel',
+        lastName: 'Bhalla',
+        email: 'nbhalla@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: neel,
+        course: fundies1,
+        role: Role.TA,
+      });
+      // Initialize Sumit as student in both
+      sumit = await UserFactory.create({
+        firstName: 'Sumit',
+        lastName: 'De',
+        email: 'sde@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: sumit,
+        course: fundies1,
+        role: Role.STUDENT,
+      });
+      await UserCourseFactory.create({
+        user: sumit,
+        course: algo,
+        role: Role.STUDENT,
+      });
+      // Initialize Angela as student in only fundies
+      angela = await UserFactory.create({
+        firstName: 'Angela',
+        lastName: 'Zheng',
+        email: 'azheng@northeastern.edu',
+      });
+      await UserCourseFactory.create({
+        user: angela,
+        course: fundies1,
+        role: Role.STUDENT,
+      });
+    });
+
+    /*
+        courseId: number,
+        page: number,
+        pageSize: number,
+        role?: Role,
+        search?: string,
+    */
+    it('returns nothing for a non-existing course id', async () => {
+      const courseId = 3;
+      const resp = await service.getUserInfo(courseId, page, pageSize);
+      expect(resp).toEqual([]);
+    });
+
+    it('returns Danish and Iris for fundies profs', async () => {
+      const courseId = 1;
+      const prof = Role.PROFESSOR;
+      const resp = await service.getUserInfo(courseId, page, pageSize, prof);
+      expect(resp.map((info) => info.name)).toEqual([
+        'Danish Farooq',
+        'Iris Liu',
+      ]);
+    });
+  });
+});

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -4,6 +4,7 @@ import {
   TACheckinTimesResponse,
   RegisterCourseParams,
   Role,
+  UserPartial,
 } from '@koh/common';
 import {
   HttpException,
@@ -14,7 +15,7 @@ import {
 import { partition } from 'lodash';
 import { EventModel, EventType } from 'profile/event-model.entity';
 import { QuestionModel } from 'question/question.entity';
-import { Between, Connection, In } from 'typeorm';
+import { Between, Brackets, Connection, getRepository, In } from 'typeorm';
 import { UserCourseModel } from '../profile/user-course.entity';
 import { SemesterModel } from 'semester/semester.entity';
 import { ProfSectionGroupsModel } from 'login/prof-section-groups.entity';
@@ -22,6 +23,7 @@ import { CourseSectionMappingModel } from 'login/course-section-mapping.entity';
 import { LastRegistrationModel } from 'login/last-registration-model.entity';
 import { LoginCourseService } from '../login/login-course.service';
 import { CourseModel } from './course.entity';
+import { UserModel } from 'profile/user.entity';
 
 @Injectable()
 export class CourseService {
@@ -231,6 +233,65 @@ export class CourseService {
       throw new HttpException(
         ERROR_MESSAGES.courseController.updateProfLastRegistered,
         HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async getUserInfo(
+    courseId: number,
+    page: number,
+    pageSize: number,
+    role?: Role,
+    search?: string,
+  ): Promise<UserPartial[]> {
+    try {
+      const query = await getRepository(UserModel)
+        .createQueryBuilder()
+        .leftJoin(
+          UserCourseModel,
+          'UserCourseModel',
+          '"UserModel".id = "UserCourseModel"."userId"',
+        )
+        .where('"UserCourseModel"."courseId" = :courseId', { courseId });
+
+      // check if searching for specific role
+      if (role) {
+        query.andWhere('"UserCourseModel".role = :role', { role });
+      }
+      // check if searching for specific name
+      if (search) {
+        const likeSearch = `%${search}%`.toUpperCase();
+        query.andWhere(
+          new Brackets((q) => {
+            q.where('UPPER("UserModel"."firstName") like :firstSearch', {
+              firstSearch: likeSearch,
+            }).orWhere('UPPER("UserModel"."lastName") like :lastSearch', {
+              lastSearch: likeSearch,
+            });
+          }),
+        );
+      }
+
+      // run query
+      const users = query
+        .select([
+          'UserModel.id',
+          'UserModel.firstName',
+          'UserModel.lastName',
+          'UserModel.photoURL',
+          'UserModel.email',
+        ])
+        .orderBy('UserModel.firstName')
+        .skip((page - 1) * pageSize)
+        .take(pageSize)
+        .getMany();
+
+      return users;
+    } catch (err) {
+      console.error(err);
+      throw new HttpException(
+        ERROR_MESSAGES.common.pageOutOfBounds,
+        HttpStatus.BAD_REQUEST,
       );
     }
   }

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -327,55 +327,47 @@ export class CourseService {
     role?: Role,
     search?: string,
   ): Promise<UserPartial[]> {
-    try {
-      const query = await getRepository(UserModel)
-        .createQueryBuilder()
-        .leftJoin(
-          UserCourseModel,
-          'UserCourseModel',
-          '"UserModel".id = "UserCourseModel"."userId"',
-        )
-        .where('"UserCourseModel"."courseId" = :courseId', { courseId });
+    const query = await getRepository(UserModel)
+      .createQueryBuilder()
+      .leftJoin(
+        UserCourseModel,
+        'UserCourseModel',
+        '"UserModel".id = "UserCourseModel"."userId"',
+      )
+      .where('"UserCourseModel"."courseId" = :courseId', { courseId });
 
-      // check if searching for specific role
-      if (role) {
-        query.andWhere('"UserCourseModel".role = :role', { role });
-      }
-      // check if searching for specific name
-      if (search) {
-        const likeSearch = `%${search}%`.toUpperCase();
-        query.andWhere(
-          new Brackets((q) => {
-            q.where('UPPER("UserModel"."firstName") like :firstSearch', {
-              firstSearch: likeSearch,
-            }).orWhere('UPPER("UserModel"."lastName") like :lastSearch', {
-              lastSearch: likeSearch,
-            });
-          }),
-        );
-      }
-
-      // run query
-      const users = query
-        .select([
-          'UserModel.id',
-          'UserModel.firstName',
-          'UserModel.lastName',
-          'UserModel.photoURL',
-          'UserModel.email',
-        ])
-        .orderBy('UserModel.firstName')
-        .skip((page - 1) * pageSize)
-        .take(pageSize)
-        .getMany();
-
-      return users;
-    } catch (err) {
-      console.error(err);
-      throw new HttpException(
-        ERROR_MESSAGES.common.pageOutOfBounds,
-        HttpStatus.BAD_REQUEST,
+    // check if searching for specific role
+    if (role) {
+      query.andWhere('"UserCourseModel".role = :role', { role });
+    }
+    // check if searching for specific name
+    if (search) {
+      const likeSearch = `%${search}%`.toUpperCase();
+      query.andWhere(
+        new Brackets((q) => {
+          q.where('UPPER("UserModel"."firstName") like :firstSearch', {
+            firstSearch: likeSearch,
+          }).orWhere('UPPER("UserModel"."lastName") like :lastSearch', {
+            lastSearch: likeSearch,
+          });
+        }),
       );
     }
+
+    // run query
+    const users = query
+      .select([
+        'UserModel.id',
+        'UserModel.firstName',
+        'UserModel.lastName',
+        'UserModel.photoURL',
+        'UserModel.email',
+      ])
+      .orderBy('UserModel.firstName')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getMany();
+
+    return users;
   }
 }

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -324,8 +324,8 @@ export class CourseService {
     courseId: number,
     page: number,
     pageSize: number,
-    role?: Role,
     search?: string,
+    role?: Role,
   ): Promise<UserPartial[]> {
     const query = await getRepository(UserModel)
       .createQueryBuilder()
@@ -342,14 +342,15 @@ export class CourseService {
     }
     // check if searching for specific name
     if (search) {
-      const likeSearch = `%${search}%`.toUpperCase();
+      const likeSearch = `%${search.replace(' ', '')}%`.toUpperCase();
       query.andWhere(
         new Brackets((q) => {
-          q.where('UPPER("UserModel"."firstName") like :firstSearch', {
-            firstSearch: likeSearch,
-          }).orWhere('UPPER("UserModel"."lastName") like :lastSearch', {
-            lastSearch: likeSearch,
-          });
+          q.where(
+            'CONCAT(UPPER("UserModel"."firstName"), UPPER("UserModel"."lastName")) like :searchString',
+            {
+              searchString: likeSearch,
+            },
+          );
         }),
       );
     }

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -18,7 +18,6 @@ export const UserFactory = new Factory(UserModel)
   .attr('email', `user@neu.edu`)
   .attr('firstName', 'User')
   .attr('lastName', 'Person')
-  .attr('photoURL', `photo@url.com`)
   .attr('hideInsights', []);
 
 export const StudentCourseFactory = new Factory(UserCourseModel).attr(

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -18,6 +18,7 @@ export const UserFactory = new Factory(UserModel)
   .attr('email', `user@neu.edu`)
   .attr('firstName', 'User')
   .attr('lastName', 'Person')
+  .attr('photoURL', `photo@url.com`)
   .attr('hideInsights', []);
 
 export const StudentCourseFactory = new Factory(UserCourseModel).attr(


### PR DESCRIPTION
# Description

This PR creates an endpoint for professors to retrieve list of users given a course id. The endpoint includes pagination, search by name substring matching, and search by role. The users are sorted alphabetically by first name when returned. Please review, this was disgusting. I hate typeORM.

Closes #843 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual Testing:
I used Postman for manual testing. You can send a GET request to `localhost:3000/api/v1/courses/3/get_user_info/1` with the DB and yarn dev running. This should get you all 5 users of the course. If you include `search` as a key, you can retrieve users based on name:

`search = e` should give you 4 users, all users minus Da-Jin.
`search = le` should give you 2 users, Alex and Stanley.
`search = Alex` should give you 1 user, Alex only.

Also searching should be case-insensitive so `alex` would also work fine.

To test pagination, you would have to either add more users (which I don't want to do) or go into the code and change PAGE_SIZE to a number that is less than 5 because there are only 5 users:

Unit Testing:
I wrote tests for general retrieval functionality, role flags, search terms, and pagination in a new spec file `course.service.spec.ts`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
