### PR TITLE
Allow students to have multiple questions across multiple courses

### DIFF
--- a/packages/app/components/Queue/Student/StudentQueue.tsx
+++ b/packages/app/components/Queue/Student/StudentQueue.tsx
@@ -76,6 +76,10 @@ const HeaderText = styled.div`
   font-variant: small-caps;
 `;
 
+const PopConfirmTitle = styled.div`
+  max-width: 400px;
+`;
+
 const CenterRow = styled(Row)`
   align-items: center;
 `;
@@ -292,7 +296,13 @@ export default function StudentQueue({
             buttons={
               !studentQuestion && (
                 <Popconfirm
-                  title="In order to join this queue, you must delete your previous question. Do you want to continue?"
+                  title={
+                    <PopConfirmTitle>
+                      You already have a question in a queue for this course, so
+                      your previous question will be deleted in order to join
+                      this queue. Do you want to continue?
+                    </PopConfirmTitle>
+                  }
                   onConfirm={() => joinQueueOpenModal(true)}
                   okText="Yes"
                   cancelText="No"

--- a/packages/server/src/question/question.controller.ts
+++ b/packages/server/src/question/question.controller.ts
@@ -103,6 +103,7 @@ export class QuestionController {
 
     const previousUserQuestion = await QuestionModel.findOne({
       where: {
+        queueId: queueId,
         creatorId: user.id,
         status: In(Object.values(OpenQuestionStatus)),
       },

--- a/packages/server/src/question/question.controller.ts
+++ b/packages/server/src/question/question.controller.ts
@@ -101,18 +101,22 @@ export class QuestionController {
       );
     }
 
-    const previousUserQuestion = await QuestionModel.findOne({
+    const previousUserQuestions = await QuestionModel.find({
+      relations: ['queue'],
       where: {
-        queueId: queueId,
         creatorId: user.id,
         status: In(Object.values(OpenQuestionStatus)),
       },
     });
 
-    if (!!previousUserQuestion) {
+    const previousCourseQuestion = previousUserQuestions.find(
+      (question) => question.queue.courseId === queue.courseId,
+    );
+
+    if (!!previousCourseQuestion) {
       if (force) {
-        previousUserQuestion.status = ClosedQuestionStatus.ConfirmedDeleted;
-        await previousUserQuestion.save();
+        previousCourseQuestion.status = ClosedQuestionStatus.ConfirmedDeleted;
+        await previousCourseQuestion.save();
       } else {
         throw new BadRequestException(
           ERROR_MESSAGES.questionController.createQuestion.oneQuestionAtATime,

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -172,29 +172,72 @@ describe('Question Integration', () => {
         })
         .expect(400);
     });
-    it("can't create more than one open question at a time", async () => {
+    it("can't create more than one open question for the same course at a time", async () => {
       const course = await CourseFactory.create({});
       const user = await UserFactory.create();
-      const queue = await QueueFactory.create({
+      const queue1 = await QueueFactory.create({
+        allowQuestions: true,
+        course: course,
+      });
+      const queue2 = await QueueFactory.create({
         allowQuestions: true,
         course: course,
       });
       await StudentCourseFactory.create({
         userId: user.id,
-        courseId: queue.courseId,
+        courseId: course.id,
       });
       await QuestionFactory.create({
-        queueId: queue.id,
+        queueId: queue1.id,
         creator: user,
+        queue: queue1,
         status: OpenQuestionStatus.Drafting,
       });
 
-      const response = await postQuestion(user, queue);
+      const response = await postQuestion(user, queue2);
 
       expect(response.status).toBe(400);
       expect(response.body.message).toBe(
         ERROR_MESSAGES.questionController.createQuestion.oneQuestionAtATime,
       );
+    });
+    it('allow multiple questions across courses', async () => {
+      const course1 = await CourseFactory.create({});
+      const course2 = await CourseFactory.create({});
+      const user = await UserFactory.create();
+      const queue1 = await QueueFactory.create({
+        allowQuestions: true,
+        course: course1,
+      });
+      const queue2 = await QueueFactory.create({
+        allowQuestions: true,
+        course: course2,
+      });
+      await StudentCourseFactory.create({
+        userId: user.id,
+        courseId: course1.id,
+      });
+      await StudentCourseFactory.create({
+        userId: user.id,
+        courseId: course2.id,
+      });
+      await QuestionFactory.create({
+        queueId: queue1.id,
+        creator: user,
+        queue: queue1,
+        status: OpenQuestionStatus.Drafting,
+      });
+
+      const response = await postQuestion(user, queue2);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        text: "Don't know recursion",
+        questionType: QuestionType.Concept,
+        groupable: true,
+      });
+      expect(await QuestionModel.count({ where: { queueId: 1 } })).toEqual(1);
+      expect(await QuestionModel.count({ where: { queueId: 2 } })).toEqual(1);
     });
     it('force a question when one is already open', async () => {
       const course = await CourseFactory.create({});


### PR DESCRIPTION
# Description
Allows one question per course for each student.

Previously, only one question is allowed per user. We believe it is more ideal to allow a student to have one question per course. This PR also updated the warning for when a student wants to create a second question for a course.

Closes #845 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] This has been manually tested in the front end. (In database: Create a second course in course_model. Add a student to the second course by adding an entry in user_course_model. On the app: Sign in as the student. Create a question in one of the courses that the student is in. Then create another question in the other course. This should not generate a warning. However, creating two questions in one course will give a warning.
- [x] One of the test in `question.controller.ts` has been adjusted to reflect that a second question in the same course (in different queues) gives a 400. A test has been added to show that a user can have one question each for two different courses.
- [x] This also has been tested with courses with more than one queues.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
