### PR TITLE
New Today Page

### DIFF
--- a/packages/app/components/Today/OpenQueueCard.tsx
+++ b/packages/app/components/Today/OpenQueueCard.tsx
@@ -143,7 +143,11 @@ const OpenQueueCard = ({
 
   return (
     <PaddedCard
-      headStyle={{ background: "#25426C", color: "#FFFFFF" }}
+      headStyle={{
+        background: "#25426C",
+        color: "#FFFFFF",
+        borderRadius: "6px 6px 0 0",
+      }}
       className={"open-queue-card"}
       title={
         <span>

--- a/packages/app/components/Today/OpenQueueCard.tsx
+++ b/packages/app/components/Today/OpenQueueCard.tsx
@@ -52,6 +52,10 @@ const QuestionNumberSpan = styled.span`
   font-size: 24px;
 `;
 
+const QueueSizeSpan = styled.span`
+  font-size: 18px;
+`;
+
 const HeaderText = styled.div`
   font-size: 14px;
   line-height: 22px;
@@ -62,9 +66,8 @@ const HeaderText = styled.div`
 `;
 
 const OpenQueueButton = styled(Button)`
-  background-color: #3684c6;
+  color: #5f6b79;
   border-radius: 6px;
-  color: white;
   font-weight: 500;
   font-size: 14px;
   margin-left: 16px;
@@ -84,9 +87,22 @@ const SaveButton = styled(Button)`
   font-size: 14px;
 `;
 
+const NotesDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  margin: 10px 10px auto 0;
+`;
+
+const RightQueueNotesRow = styled.div`
+  display: flex;
+`;
 const NotesInput = styled(Input.TextArea)`
   border-radius: 6px;
   border: 1px solid #b8c4ce;
+  //display: flex;
+  //flex-grow: 1;
+  margin: auto 0px auto 10px;
 `;
 
 const Notes = styled.div`
@@ -129,10 +145,16 @@ const OpenQueueCard = ({
     <PaddedCard
       headStyle={{ background: "#25426C", color: "#FFFFFF" }}
       className={"open-queue-card"}
-      title={`${queue.room} ${
-        queue.isProfessorQueue ? `(Professor queue)` : ``
-      }`}
-      extra={`${queue.queueSize} in queue`}
+      title={
+        <span>
+          {queue.room} <i>{queue.isProfessorQueue ? `(Professor)` : ``}</i>{" "}
+        </span>
+      }
+      extra={
+        <span>
+          <QueueSizeSpan>{queue.queueSize}</QueueSizeSpan> in queue
+        </span>
+      }
     >
       <QueueInfoRow>
         <HeaderDiv>
@@ -157,11 +179,9 @@ const OpenQueueCard = ({
               as={`/course/${cid}/queue/${queue.id}`}
             >
               <OpenQueueButton
-                type="primary"
-                style={{ color: `#5F6B79`, borderColor: `#5F6B79` }}
+                style={{}}
                 size="large"
                 data-cy="open-queue-button"
-                ghost
               >
                 Open Queue
               </OpenQueueButton>
@@ -189,13 +209,13 @@ const OpenQueueCard = ({
         </div>
         <OpenQueueCardDivider />
         {editingNotes ? (
-          <div>
+          <NotesDiv>
             <NotesInput
               defaultValue={queue.notes}
               value={updatedNotes}
               onChange={(e) => setUpdatedNotes(e.target.value as any)}
             />
-          </div>
+          </NotesDiv>
         ) : queue.notes ? (
           <div>
             <Linkify
@@ -220,7 +240,7 @@ const OpenQueueCard = ({
             <i> no notes provided</i>
           </div>
         )}
-        <RightQueueInfoRow>
+        <RightQueueNotesRow>
           {editingNotes && (
             <SaveButton onClick={handleUpdate} size="large">
               Save Changes
@@ -240,7 +260,7 @@ const OpenQueueCard = ({
               )}
             </QueueCardButtonRow>
           )}
-        </RightQueueInfoRow>
+        </RightQueueNotesRow>
       </Row>
     </PaddedCard>
   );

--- a/packages/app/components/Today/OpenQueueCard.tsx
+++ b/packages/app/components/Today/OpenQueueCard.tsx
@@ -166,14 +166,14 @@ const OpenQueueCard = ({
           staff checked in
         </HeaderDiv>
         <RightQueueInfoRow>
-          <Space
-            direction="vertical"
-            size="middle"
-            style={{ display: "flex", alignItems: "center" }}
-          >
+          <Space direction="vertical" align="end" size="middle">
             {!queue.allowQuestions && (
               <Tooltip title="This queue is no longer accepting questions">
-                <Tag icon={<StopOutlined />} color="error">
+                <Tag
+                  icon={<StopOutlined />}
+                  color="error"
+                  style={{ margin: 0 }}
+                >
                   Not Accepting Questions
                 </Tag>
               </Tooltip>

--- a/packages/app/components/Today/OpenQueueCard.tsx
+++ b/packages/app/components/Today/OpenQueueCard.tsx
@@ -103,6 +103,11 @@ const QueueCardButtonRow = styled(Row)`
   padding-top: 10px;
 `;
 
+const OpenQueueCardDivider = styled(Divider)`
+  margin-top: 12px;
+  margin-bottom: 0;
+`;
+
 const OpenQueueCard = ({
   queue,
   isTA,
@@ -182,7 +187,7 @@ const OpenQueueCard = ({
             </Tooltip>
           ))}
         </div>
-        <Divider />
+        <OpenQueueCardDivider />
         {editingNotes ? (
           <div>
             <NotesInput

--- a/packages/app/components/Today/TACheckinButton.tsx
+++ b/packages/app/components/Today/TACheckinButton.tsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 import { useCourse } from "../../hooks/useCourse";
 
 export const CheckinButton = styled(Button)`
-  background: #2a9187;
+  background: #1890ff;
   border-radius: 6px;
   color: white;
   font-weight: 500;
@@ -52,17 +52,15 @@ export default function TACheckinButton({
     //trying to limit changes to the frontend, all queues will have the room online
 
     try {
-       const redirectID = await API.taStatus.checkIn(courseId, room);
-    mutateCourse();
-    router.push(
-      "/course/[cid]/queue/[qid]",
-      `/course/${courseId}/queue/${redirectID.id}`
-    );
-
+      const redirectID = await API.taStatus.checkIn(courseId, room);
+      mutateCourse();
+      router.push(
+        "/course/[cid]/queue/[qid]",
+        `/course/${courseId}/queue/${redirectID.id}`
+      );
     } catch (err) {
       message.error(err.response?.data?.message);
     }
-   
   }
 
   const [checkoutModalInfo, setCheckoutModalInfo] = useState<{

--- a/packages/app/pages/course/[cid]/today.tsx
+++ b/packages/app/pages/course/[cid]/today.tsx
@@ -30,6 +30,24 @@ const Title = styled.div`
   font-size: 30px;
   color: #212934;
 `;
+const RoleColorSpan = styled.span`
+  color: #3684c6;
+  font-weight: bold;
+`;
+
+function roleToString(role: Role) {
+  switch (role) {
+    case Role.TA:
+      return "TA";
+    case Role.STUDENT:
+      return "Student";
+    case Role.PROFESSOR:
+      return "Professor";
+    default:
+      return "";
+  }
+}
+
 /*
 function arrayRotate(arr, count) {
   const adjustedCount = (arr.length + count) % arr.length;
@@ -81,11 +99,14 @@ export default function Today(): ReactElement {
               <Title>Current Office Hours</Title>
               <TodayPageCheckinButton />
             </Row>
-            {role === Role.PROFESSOR && (
-              <Row>
-                <div>You are a professor for this course</div>
-              </Row>
-            )}
+            <Row>
+              <div>
+                <i>
+                  You are a <RoleColorSpan>{roleToString(role)}</RoleColorSpan>{" "}
+                  for this course
+                </i>
+              </div>
+            </Row>
             {course?.queues?.filter((q) => q.isOpen).length === 0 ? (
               <h1 style={{ paddingTop: "100px" }}>
                 There are currently no open queues
@@ -97,7 +118,7 @@ export default function Today(): ReactElement {
                   <OpenQueueCard
                     key={q.id}
                     queue={q}
-                    isTA={role === Role.TA}
+                    isTA={role === Role.TA || role === Role.PROFESSOR}
                     updateQueueNotes={updateQueueNotes}
                   />
                 ))

--- a/packages/app/styles/global.css
+++ b/packages/app/styles/global.css
@@ -52,6 +52,10 @@ body {
   padding-inline-start: 5px;
 }
 
+.open-queue-card .ant-card-extra {
+  color: #FFFFFF;
+}
+
 @media only percy {
   .hide-in-percy {
     visibility: hidden;


### PR DESCRIPTION
# Description

Changes to revamp today page according to Meghan's figma designs.  Also addresses bug where professors couldnt edit queue notes from the today page. 

All changes are cosmetic in nature, no logic changes.

Checked in:
![frame_1](https://user-images.githubusercontent.com/11274412/161109441-d32edab6-de57-43ff-81dd-a7ca48a095bc.png)
Checked out:
![frame_2](https://user-images.githubusercontent.com/11274412/161109439-817ab27d-5cd3-450f-8107-0c1b97606600.png)
Disabled Questions:
![frame_3](https://user-images.githubusercontent.com/11274412/161109436-22bc3417-4e5f-417e-afa9-aa92023f71dd.png)
When notes are populated:
![frame_4](https://user-images.githubusercontent.com/11274412/161109442-c7977ad9-80a3-4569-9526-b59cafbab908.png)


Closes #772 



Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by inspection, might need to fix cypress tests since we arent going with the same queue disabled icon, etc.
# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
