### PR TITLE
Caching + pagination for most questions asked

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -3,7 +3,7 @@ import {
   CreateAlertResponse,
   CreateQuestionParams,
   CreateQuestionResponse,
-  DateRangeType,
+  InsightParamsType,
   DesktopNotifBody,
   DesktopNotifPartial,
   GetAlertsResponse,
@@ -225,7 +225,7 @@ class APIClient {
     get: async (
       courseId: number,
       insightName: string,
-      params: DateRangeType
+      params: InsightParamsType
     ): Promise<GetInsightOutputResponse> => {
       return this.req(
         "GET",

--- a/packages/app/components/Insights/components/SimpleTable.tsx
+++ b/packages/app/components/Insights/components/SimpleTable.tsx
@@ -1,20 +1,33 @@
 import { SimpleTableOutputType } from "@koh/common";
-import { Table } from "antd";
+import { Pagination, Table } from "antd";
 import React, { ReactElement } from "react";
+import { SetStateAction } from "react";
+import { Dispatch } from "react";
 
 interface SimpleTableTypes {
   output: SimpleTableOutputType;
+  currentPage: number;
+  setPage: Dispatch<SetStateAction<number>>;
 }
 
-export const SimpleTable = ({ output }: SimpleTableTypes): ReactElement => {
+export const SimpleTable = ({
+  output,
+  currentPage,
+  setPage,
+}: SimpleTableTypes): ReactElement => {
   return (
-    <>
+    <div>
       <Table
         dataSource={output.dataSource}
         columns={output.columns}
-        scroll={{ y: 1500 }}
-        pagination={{ pageSize: 6, simple: true }}
+        pagination={false}
       />
-    </>
+      <Pagination
+        current={currentPage}
+        pageSize={6}
+        total={output.totalStudents}
+        onChange={(page) => setPage(page)}
+      />
+    </div>
   );
 };

--- a/packages/app/pages/course/[cid]/insights.tsx
+++ b/packages/app/pages/course/[cid]/insights.tsx
@@ -99,9 +99,9 @@ export default function Insights(): ReactElement {
                 Date Range
               </b>
               <RangePicker
-                onChange={(_, dateString) => {
-                  setDateRange({ start: dateString[0], end: dateString[1] });
-                }}
+                onChange={(_, dateString) =>
+                  setDateRange({ start: dateString[0], end: dateString[1] })
+                }
               />
             </div>
             <Button

--- a/packages/app/pages/course/[cid]/insights.tsx
+++ b/packages/app/pages/course/[cid]/insights.tsx
@@ -161,13 +161,18 @@ function RenderInsight({
   const router = useRouter();
   const { cid } = router.query;
 
+  const limit = insightName === "MostActiveStudents" ? 75 : null;
   const { data: insightOutput } = useSWR(
     cid &&
-      `api/v1/insights/${cid}/${insightName}?start=${dateRange.start}&end=${dateRange.end}`,
+      `api/v1/insights/${cid}/${insightName}?start=${dateRange.start}&end=${
+        dateRange.end
+      }${limit ? "limit&75" : ""}`,
     async () =>
       await API.insights.get(Number(cid), insightName, {
         start: dateRange.start,
         end: dateRange.end,
+        limit,
+        offset: null,
       })
   );
 

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -796,6 +796,7 @@ export type BarChartOutputType = {
 export type SimpleTableOutputType = {
   dataSource: StringMap<string>[];
   columns: StringMap<string>[];
+  totalStudents: number;
 };
 
 export type StringMap<T> = {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -807,6 +807,13 @@ export type DateRangeType = {
   end: string;
 };
 
+export type InsightParamsType = {
+  start: string;
+  end: string;
+  limit: number;
+  offset: number;
+};
+
 export const ERROR_MESSAGES = {
   courseController: {
     checkIn: {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -14,6 +14,7 @@ import {
   ValidateIf,
 } from "class-validator";
 import "reflect-metadata";
+import { Cache } from "cache-manager";
 
 export const PROD_URL = "https://officehours.khoury.northeastern.edu";
 export const STAGING_URL = "https://staging.khouryofficehours.com";
@@ -764,7 +765,10 @@ export interface InsightObject {
   roles: Role[];
   component: InsightComponent;
   size: "default" | "small";
-  compute: (insightFilters: any) => Promise<PossibleOutputTypes>;
+  compute: (
+    insightFilters: any,
+    cacheManager?: Cache
+  ) => Promise<PossibleOutputTypes>;
 }
 
 export enum InsightComponent {

--- a/packages/server/src/insights/insight-objects.ts
+++ b/packages/server/src/insights/insight-objects.ts
@@ -112,9 +112,9 @@ export const MostActiveStudents: InsightObject = {
   async compute(filters, cacheManager: Cache): Promise<SimpleTableOutputType> {
     const dataSource = await getCachedActiveStudents(cacheManager, filters);
     const totalStudents: number = await addFilters({
-      query: createQueryBuilder(QuestionModel).select(),
-      modelName: QuestionModel.name,
-      allowedFilters: ['courseId', 'timeframe'],
+      query: createQueryBuilder(UserCourseModel).where("role = 'student'"),
+      modelName: UserCourseModel.name,
+      allowedFilters: ['courseId', 'role'],
       filters,
     }).getCount();
     return {

--- a/packages/server/src/insights/insight-objects.ts
+++ b/packages/server/src/insights/insight-objects.ts
@@ -154,7 +154,7 @@ const getCachedQuestions = async (
   const cacheLengthInSeconds = 3600;
   return cacheManager.wrap(
     `questions/${courseId}/${getStartString}:${getEndString}`,
-    () => getQuestions(courseId),
+    () => getQuestions(filters),
     { ttl: cacheLengthInSeconds },
   );
 };

--- a/packages/server/src/insights/insights.controller.ts
+++ b/packages/server/src/insights/insights.controller.ts
@@ -19,6 +19,7 @@ import {
   ERROR_MESSAGES,
   ListInsightsResponse,
   Role,
+  SimpleTableOutputType,
 } from '@koh/common';
 import { User } from '../decorators/user.decorator';
 import { INSIGHTS_MAP } from './insight-objects';
@@ -43,6 +44,8 @@ export class InsightsController {
     @Param('insightName') insightName: string,
     @Query('start') start: string,
     @Query('end') end: string,
+    @Query('limit') limit: number,
+    @Query('offset') offset: number,
   ): Promise<GetInsightOutputResponse> {
     // Check that the insight name is valid
     const insightNames = Object.keys(INSIGHTS_MAP);
@@ -74,10 +77,21 @@ export class InsightsController {
       });
     }
 
-    const insight = await this.insightsService.computeOutput({
+    let insight = await this.insightsService.computeOutput({
       insight: INSIGHTS_MAP[insightName],
       filters,
     });
+
+    if (insightName === 'MostActiveStudents') {
+      let dataSource = (insight as SimpleTableOutputType).dataSource;
+      if (offset) {
+        dataSource = dataSource.slice(offset, dataSource.length);
+      }
+      if (limit) {
+        dataSource = dataSource.slice(0, limit);
+      }
+      insight = { ...(insight as SimpleTableOutputType), dataSource };
+    }
 
     return insight;
   }

--- a/packages/server/src/insights/insights.module.ts
+++ b/packages/server/src/insights/insights.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, CacheModule } from '@nestjs/common';
 import { InsightsCommand } from './insights.command';
 import { InsightsService } from './insights.service';
 import { InsightsController } from './insights.controller';
 
 @Module({
   controllers: [InsightsController],
+  imports: [CacheModule.register()],
   providers: [InsightsCommand, InsightsService],
 })
 export class InsightsModule {}

--- a/packages/server/src/insights/insights.service.spec.ts
+++ b/packages/server/src/insights/insights.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CacheModule } from '@nestjs/common';
 import { TestTypeOrmModule } from '../../test/util/testUtils';
 import { Connection } from 'typeorm';
 import { InsightsService } from './insights.service';
@@ -23,7 +24,7 @@ describe('InsightsService', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [TestTypeOrmModule],
+      imports: [TestTypeOrmModule, CacheModule.register()],
       providers: [InsightsService],
     }).compile();
 

--- a/packages/server/src/insights/insights.service.ts
+++ b/packages/server/src/insights/insights.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
 import { Connection } from 'typeorm';
 import { Filter, INSIGHTS_MAP } from './insight-objects';
 import {
@@ -7,6 +7,7 @@ import {
   ListInsightsResponse,
 } from '@koh/common';
 import { UserModel } from 'profile/user.entity';
+import { Cache } from 'cache-manager';
 
 type ComputeOutputParams = {
   insight: InsightObject;
@@ -20,14 +21,17 @@ type GenerateAllInsightParams = {
 
 @Injectable()
 export class InsightsService {
-  constructor(private connection: Connection) {}
+  constructor(
+    private connection: Connection,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+  ) {}
 
   // Compute the output data for an insight and add it to the insight response
   async computeOutput({
     insight,
     filters,
   }: ComputeOutputParams): Promise<PossibleOutputTypes> {
-    const output = await insight.compute(filters);
+    const output = await insight.compute(filters, this.cacheManager);
     return output;
   }
 


### PR DESCRIPTION
# Description

Added functionality to insights query that caches the big "Questions Asked" query and allows the result to be paginated/offset. Motivation is to allow frontend to retrieve all data for this insight without requesting it all at once and overloading it. In its current state, the frontend does what it did before and only gets 75 (will be updated in next PR)

Closes #844

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test A: Made Postman queries to insights API to confirm that the MostQuestionsAsked query works as before, but also allows for limit/offset query param (To do this yourself, you have to get the cookie from the Chrome console log by logging into dev as professor before make the Postman request)
- [x] Test B: Checked that frontend works with limit/offset used in queries to backend and only 6 frontend table items are requested at time. Also confirmed that other insights are not rerendered when you iterate through the most questions asked table

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
