### PR TITLE
Fix error handling for calendar fetch

### DIFF
--- a/packages/server/src/resources/resources.controller.ts
+++ b/packages/server/src/resources/resources.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  HttpException,
   HttpService,
   HttpStatus,
   Param,
@@ -44,16 +43,30 @@ export class ResourcesController {
           if (course === null || course === undefined) {
             console.error(
               ERROR_MESSAGES.courseController.courseNotFound +
-                'Course ID: ' +
+                ' Course ID: ' +
                 courseId,
             );
-            throw new HttpException(
-              ERROR_MESSAGES.courseController.courseNotFound,
-              HttpStatus.NOT_FOUND,
-            );
+            res
+              .status(HttpStatus.NOT_FOUND)
+              .send({
+                message: ERROR_MESSAGES.courseController.courseNotFound,
+              });
+            return;
           }
-          const cal = await this.resourcesService.refetchCalendar(course);
-          res.send(cal);
+          try {
+            const cal = await this.resourcesService.refetchCalendar(course);
+            res.send(cal);
+          } catch (err) {
+            console.error(ERROR_MESSAGES.resourcesService.saveCalError, err);
+            res
+              .status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .send({
+                message:
+                  ERROR_MESSAGES.resourcesService.saveCalError +
+                  ': ' +
+                  err.message,
+              });
+          }
         }
       },
     );


### PR DESCRIPTION
# Description

Changes how the GET /calendar endpoint returns errors - it wasn't actually returning errors to the request, and was just crashing the backend. I think this was either because it's using a `Response` object instead of directly returning the response, or because the errors were getting thrown within a callback instead of in the actual endpoint function. Anyways this should correctly return errors to the client now (for nonexistent courses, problems with writing to disk, etc)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] I just tested this manually


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
