### PR TITLE
insert a clear queue button 

### DIFF
--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -37,7 +37,6 @@ export const NotesText = styled.div`
 `;
 
 // New queue styled components start here
-
 const InfoColumnContainer = styled.div`
   flex-shrink: 0;
   padding-bottom: 30px;
@@ -99,13 +98,27 @@ const QueueRoomGroup = styled.div`
 const DisableQueueButton = styled(QueueInfoColumnButton)`
   color: white;
   background: #da3236;
-  bottom: 0;
-  position: absolute;
   &:hover,
   &:focus {
-    color: white;
-    background: #f76c6c;
+    color: #da3236;
+    background: #fff;
+    border-color: #da3236;
   }
+`;
+
+const ClearQueueButton = styled(QueueInfoColumnButton)`
+  background-color: #1890ff;
+  color: white;
+`;
+
+const QueueManagementBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  color: white;
+  width: 100%;
+  height: 100%;
+  bottom: 0;
 `;
 
 interface QueueInfoColumnProps {
@@ -123,9 +136,15 @@ export function QueueInfoColumn({
 
   const disableQueue = async () => {
     await API.queues.disable(queueId);
-    await mutateQueue(); // cope
+    await mutateQueue();
     message.success("Successfully disabled queue: " + queue.room);
     await Router.push("/");
+  };
+
+  const clearQueue = async () => {
+    await API.queues.clean(queueId);
+    await mutateQueue();
+    message.success("Successfully cleaned queue: " + queue.room);
   };
 
   const confirmDisable = () => {
@@ -188,13 +207,16 @@ export function QueueInfoColumn({
       <StaffH2>Staff</StaffH2>
       <TAStatuses queueId={queueId} />
       {isStaff && (
-        <DisableQueueButton
-          onClick={confirmDisable}
-          data-cy="queue-disable-button"
-          disabled={queue?.isDisabled}
-        >
-          {queue?.isDisabled ? `Queue deleted` : `Delete Queue`}
-        </DisableQueueButton>
+        <QueueManagementBox>
+          <ClearQueueButton onClick={clearQueue}>Clear Queue</ClearQueueButton>
+          <DisableQueueButton
+            onClick={confirmDisable}
+            data-cy="queue-disable-button"
+            disabled={queue?.isDisabled}
+          >
+            {queue?.isDisabled ? `Queue deleted` : `Delete Queue`}
+          </DisableQueueButton>
+        </QueueManagementBox>
       )}
     </InfoColumnContainer>
   );

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -6,7 +6,7 @@ import {
   NotificationOutlined,
   StopOutlined,
 } from "@ant-design/icons";
-import { Button, message, Modal, Tooltip } from "antd";
+import { Button, message, Modal, Popconfirm, Tooltip } from "antd";
 import { ButtonProps } from "antd/lib/button";
 import Linkify from "react-linkify";
 import moment from "moment";
@@ -158,7 +158,8 @@ export function QueueInfoColumn({
       title: `Please Confirm!`,
       icon: <ExclamationCircleOutlined />,
       style: { whiteSpace: "pre-wrap" },
-      content: `Please confirm that you want to disable the queue: ${queue.room}.\nThis queue will no longer appear in the app, and any students currently in the queue will be removed.`,
+      content: `Please confirm that you want to disable the queue: ${queue.room}.\n
+      This queue will no longer appear in the app, and any students currently in the queue will be removed.`,
       onOk() {
         disableQueue();
       },
@@ -214,7 +215,18 @@ export function QueueInfoColumn({
       <TAStatuses queueId={queueId} />
       {isStaff && (
         <QueueManagementBox>
-          <ClearQueueButton onClick={clearQueue}>Clear Queue</ClearQueueButton>
+          <Popconfirm
+            title={
+              "Are you sure you want to clear all students from the queue?"
+            }
+            okText="Yes"
+            cancelText="No"
+            placement="top"
+            arrowPointAtCenter={true}
+            onConfirm={clearQueue}
+          >
+            <ClearQueueButton>Clear Queue</ClearQueueButton>
+          </Popconfirm>
           <DisableQueueButton
             onClick={confirmDisable}
             data-cy="queue-disable-button"

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -107,8 +107,14 @@ const DisableQueueButton = styled(QueueInfoColumnButton)`
 `;
 
 const ClearQueueButton = styled(QueueInfoColumnButton)`
-  background-color: #1890ff;
+  background-color: #ff8c00;
   color: white;
+  &:hover,
+  &:focus {
+    color: #ff8c00;
+    background: #fff;
+    border-color: #ff8c00;
+  }
 `;
 
 const QueueManagementBox = styled.div`


### PR DESCRIPTION
# Description
Button on queue page to allow TAs to clear the queue. Also fixing up some CSS (ty to Venkat for the assistance). 

https://user-images.githubusercontent.com/59672089/164585322-83325223-05f9-4db0-9326-e22e1562635c.mov



Closes #878 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## Testing
Manually tested -- backend endpoint is already tested. I could write a cypress test, but that may be a bit much. 