### PR TITLE
Df/fullcal tooltip

### DIFF
--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -100,6 +100,7 @@ export default function SchedulePanel({
               url: fetchCalUrl(false),
               format: "ics",
             }}
+            scrollTime="08:00:00" // auto set each day's view to begin at 8AM
             initialView={defaultView}
             headerToolbar={{
               start: "title",

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -81,7 +81,7 @@ export default function SchedulePanel({
   };
 
   return (
-    <div>
+    <div className="hide-in-percy">
       <SpinnerContainer ref={spinnerRef}>
         <Spin />
       </SpinnerContainer>

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -1,10 +1,10 @@
 import { ReactElement, useState, useEffect, useRef } from "react";
-import FullCalendar from "@fullcalendar/react"; // must go before plugins
-import timeGridPlugin from "@fullcalendar/timegrid";
+import FullCalendar, { EventContentArg } from "@fullcalendar/react"; // must go before plugins
+import timeGridPlugin, { DayTimeColsView } from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import iCalendarPlugin from "@fullcalendar/icalendar";
-import { Button, Spin } from "antd";
+import { Button, Spin, Tooltip } from "antd";
 import { useRoleInCourse } from "../../hooks/useRoleInCourse";
 import { Role } from "@koh/common";
 import styled from "styled-components";
@@ -39,7 +39,7 @@ type ScheduleProps = {
 
 export default function SchedulePanel({
   courseId,
-  defaultView = "timeGridWeek"
+  defaultView = "timeGridWeek",
 }: ScheduleProps): ReactElement {
   // iCalendarPlugin uses XMLHttpRequest, which is not available when Next.js is trying to
   // server-side render the page. Using state to only render the <FullCalendar> component after
@@ -52,17 +52,31 @@ export default function SchedulePanel({
   useEffect(() => {
     // it is now safe to render the client-side only component
     setIsClientSide(true);
-  });
+  }, []);
+
+  const renderEventContent = (arg: EventContentArg) => {
+    const data = calendarRef.current.getApi().getCurrentData();
+    const viewSpec = data.viewSpecs[arg.view.type].component;
+    if (viewSpec === DayTimeColsView) {
+      return (
+        <Tooltip title={`${arg.timeText}: ${arg.event.title}`}>
+          <span>
+            <b>{arg.timeText}</b> {arg.event.title}{" "}
+          </span>
+        </Tooltip>
+      );
+    }
+  };
 
   const fetchCalUrl = (refresh: boolean) =>
     `/api/v1/resources/calendar/${courseId}/refresh=${refresh}`;
 
   const refetchEvents = () => {
     const calApi = calendarRef.current.getApi();
-    calApi.getEventSources().forEach(src => src.remove());
+    calApi.getEventSources().forEach((src) => src.remove());
     calApi.addEventSource({
       url: fetchCalUrl(true),
-      format: "ics"
+      format: "ics",
     });
   };
 
@@ -79,19 +93,19 @@ export default function SchedulePanel({
               timeGridPlugin,
               iCalendarPlugin,
               dayGridPlugin,
-              listPlugin
+              listPlugin,
             ]}
             events={{
               url: fetchCalUrl(false),
-              format: "ics"
+              format: "ics",
             }}
             initialView={defaultView}
             headerToolbar={{
               start: "title",
               center: "dayGridMonth timeGridWeek timeGridDay listWeek",
-              end: "today prev,next"
+              end: "today prev,next",
             }}
-            loading={loading => {
+            loading={(loading) => {
               // FullCal is stupid so if you setState in this cb you get into an infinite render loop
               // https://stackoverflow.com/questions/66818770/fullcalendar-react-loading-function-problem
               // So we're just floating a spinner on top of the calendar and setting its display property
@@ -99,6 +113,7 @@ export default function SchedulePanel({
                 spinnerRef.current.style.display = loading ? "flex" : "none";
             }}
             height="70vh"
+            eventContent={renderEventContent}
           />
         </CalendarWrapper>
       )}

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -82,7 +82,7 @@ export default function SchedulePanel({
   };
 
   return (
-    <div className="hide-in-percy">
+    <div>
       <SpinnerContainer ref={spinnerRef}>
         <Spin />
       </SpinnerContainer>

--- a/packages/app/components/Schedule/SchedulePanel.tsx
+++ b/packages/app/components/Schedule/SchedulePanel.tsx
@@ -54,6 +54,7 @@ export default function SchedulePanel({
     setIsClientSide(true);
   }, []);
 
+  // allows us to render tooltips around events (in case of cluttered calendars)
   const renderEventContent = (arg: EventContentArg) => {
     const data = calendarRef.current.getApi().getCurrentData();
     const viewSpec = data.viewSpecs[arg.view.type].component;
@@ -61,7 +62,7 @@ export default function SchedulePanel({
       return (
         <Tooltip title={`${arg.timeText}: ${arg.event.title}`}>
           <span>
-            <b>{arg.timeText}</b> {arg.event.title}{" "}
+            <strong>{arg.timeText}</strong> {arg.event.title}
           </span>
         </Tooltip>
       );

--- a/packages/app/styles/global.css
+++ b/packages/app/styles/global.css
@@ -75,7 +75,6 @@ body {
   .rbc-toolbar {
     visibility: hidden;
   }
-
   .fc-col-header-cell-cushion {
     visibility: hidden;
   }
@@ -84,7 +83,7 @@ body {
     visibility: hidden;
   }
 
-  .fc-event-main {
+  .fc-event {
     visibility: hidden;
   }
 }

--- a/packages/app/styles/global.css
+++ b/packages/app/styles/global.css
@@ -75,4 +75,16 @@ body {
   .rbc-toolbar {
     visibility: hidden;
   }
+
+  .fc-col-header-cell-cushion {
+    visibility: hidden;
+  }
+
+  .fc-toolbar-title {
+    visibility: hidden;
+  }
+
+  .fc-event-main {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
# Description
Adds a tooltip to the week/day views of the schedule panel so people can view event information when the calendar is cluttered. Tooltip launches on event title hover (not event block hover). I dont really understand what i did but it works and thats all that matters 😎 

i also opted to hide the calendar in percy since it was causing some inconsistencies (between events on the given day and the day title). 

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
LOOK AT MY VIDEO KIDDOS

https://user-images.githubusercontent.com/59672089/165213984-f7915d33-cad8-4e96-a4c0-440fd9517303.mov
