### PR TITLE
cannot hit rephrase alert if question status is drafting

### DIFF
--- a/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
+++ b/packages/app/components/Queue/TA/TAQueueDetailButtons.tsx
@@ -152,6 +152,11 @@ export default function TAQueueDetailButtons({
           false,
           "The student has already been asked to rephrase their question",
         ];
+      } else if (question.status === OpenQuestionStatus.Drafting) {
+        return [
+          false,
+          "The student must finish drafting before they can be asked to rephrase their question",
+        ];
       } else {
         return [true, "Ask the student to add more detail to their question"];
       }


### PR DESCRIPTION
# Description
minor case, TAs cant see student text while theyre drafting so it does not make sense for them to ask students to rephrase their question 

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] it is very straightforward
