### PR TITLE
Select an existing queue typo fix

### DIFF
--- a/packages/app/components/Today/QueueCheckInModal.tsx
+++ b/packages/app/components/Today/QueueCheckInModal.tsx
@@ -58,7 +58,7 @@ export default function QueueCheckInModal({
           <Select
             showSearch
             style={{ width: 200 }}
-            placeholder="Select a course"
+            placeholder="Select a queue"
             optionFilterProp="children"
             onChange={onQueueUpdate}
             data-cy="select-existing-queue"


### PR DESCRIPTION
# Description
Fixed typo for queue selection placeholder ("Select a course" => "Select a queue")

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
