### PR TITLE
Save pending section groups for returning profs

### DIFF
--- a/packages/app/components/Nav/NavBar.tsx
+++ b/packages/app/components/Nav/NavBar.tsx
@@ -115,7 +115,7 @@ interface NavBarProps {
 export default function NavBar({ courseId }: NavBarProps): ReactElement {
   const profile = useProfile();
   if (!courseId) {
-    courseId = profile?.courses[0].course.id;
+    courseId = profile?.courses[0]?.course?.id;
   }
 
   const [_defaultCourse, setDefaultCourse] = useLocalStorage(
@@ -138,7 +138,7 @@ export default function NavBar({ courseId }: NavBarProps): ReactElement {
 
   const courseSelector = (
     <Menu>
-      {profile?.courses.map((c) => (
+      {profile?.courses?.map((c) => (
         <CoursesMenuItem
           key={c.course.id}
           onClick={() => setDefaultCourse(c.course)}

--- a/packages/server/src/login/login-course.service.ts
+++ b/packages/server/src/login/login-course.service.ts
@@ -95,6 +95,7 @@ export class LoginCourseService {
       });
       if (profSectionGroups) {
         profSectionGroups.sectionGroups = info.courses as KhouryProfCourse[];
+        await profSectionGroups.save();
       } else {
         await ProfSectionGroupsModel.create({
           profId: user.id,


### PR DESCRIPTION
# Description
Somehow we never caught this, but we weren't saving the ProfSectionGroupsModels after updating them with new section groups from khoury admin. Hence when profs try to register for a new semester, their pending courses aren't there. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] in my mind palace i have calculated the results (jk we dont know if this will actually fix things, gotta ping grob after deploy)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
