### PR TITLE
add scrollbars to queue text

### DIFF
--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -97,8 +97,9 @@ const QueueInfo = styled.div`
 `;
 
 const QueueText = styled.div`
-  height: 200px;
+  max-height: 200px;
   overflow-y: auto;
+  width: 100%;
 `;
 
 const DisableQueueButton = styled(QueueInfoColumnButton)`

--- a/packages/app/components/Queue/QueueListSharedComponents.tsx
+++ b/packages/app/components/Queue/QueueListSharedComponents.tsx
@@ -96,6 +96,11 @@ const QueueInfo = styled.div`
   margin-bottom: 24px;
 `;
 
+const QueueText = styled.div`
+  height: 200px;
+  overflow-y: auto;
+`;
+
 const DisableQueueButton = styled(QueueInfoColumnButton)`
   color: white;
   background: #da3236;
@@ -193,20 +198,22 @@ export function QueueInfoColumn({
       {queue?.notes && (
         <QueuePropertyRow>
           <NotificationOutlined />
-          <Linkify
-            componentDecorator={(decoratedHref, decoratedText, key) => (
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={decoratedHref}
-                key={key}
-              >
-                {decoratedText}
-              </a>
-            )}
-          >
-            <QueuePropertyText>{queue.notes}</QueuePropertyText>
-          </Linkify>
+          <QueueText>
+            <Linkify
+              componentDecorator={(decoratedHref, decoratedText, key) => (
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={decoratedHref}
+                  key={key}
+                >
+                  {decoratedText}
+                </a>
+              )}
+            >
+              <QueuePropertyText>{queue.notes}</QueuePropertyText>
+            </Linkify>
+          </QueueText>
         </QueuePropertyRow>
       )}
       <QueueUpToDateInfo queueId={queueId} />


### PR DESCRIPTION
# Description
queue text is now scrollable on the queue page. height is 200px max

closes #895

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Manually (vid below)

https://user-images.githubusercontent.com/59672089/169447347-919777d8-fce5-4903-8053-dcf2a4d3d554.mov

https://user-images.githubusercontent.com/59672089/169448521-ecd84189-8c0f-436c-81c0-2ddd01603bd1.mov

<img width="357" alt="image" src="https://user-images.githubusercontent.com/59672089/169448554-91863746-e9a8-4e0d-8d1a-23f704091875.png">

# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
