### PR TITLE
Don't save cals for disabled courses

### DIFF
--- a/cypress/integration/ta/queue_create_inperson_or_online.spec.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.spec.js
@@ -76,11 +76,13 @@ describe('Can successfully create queues', () => {
             // make sure it says our room name (success!, p2 logged in)
             cy.get("[data-cy='room-title']")
                 .contains(roomName);
+            
+            // will this keep cypress from retrying the calendar url?
+            cy.visit("/settings", {timeout: 20000}); 
         });
 
 
         it('Join an online queue via modal', function () {
-            cy.visit("/settings", {timeout: 20000});
             createQueue({
                 courseId: "ta.course.id",
             });

--- a/cypress/integration/ta/queue_create_inperson_or_online.spec.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.spec.js
@@ -80,6 +80,7 @@ describe('Can successfully create queues', () => {
 
 
         it('Join an online queue via modal', function () {
+            cy.visit("/settings", {timeout: 20000});
             createQueue({
                 courseId: "ta.course.id",
             });

--- a/packages/server/src/resources/resources.controller.ts
+++ b/packages/server/src/resources/resources.controller.ts
@@ -40,17 +40,15 @@ export class ResourcesController {
           res.sendFile(filename, { root: process.env.UPLOAD_LOCATION });
         } else {
           const course = await CourseModel.findOne(courseId);
-          if (course === null || course === undefined) {
+          if (course === null || course === undefined || !course.enabled) {
             console.error(
               ERROR_MESSAGES.courseController.courseNotFound +
                 ' Course ID: ' +
                 courseId,
             );
-            res
-              .status(HttpStatus.NOT_FOUND)
-              .send({
-                message: ERROR_MESSAGES.courseController.courseNotFound,
-              });
+            res.status(HttpStatus.NOT_FOUND).send({
+              message: ERROR_MESSAGES.courseController.courseNotFound,
+            });
             return;
           }
           try {
@@ -58,14 +56,12 @@ export class ResourcesController {
             res.send(cal);
           } catch (err) {
             console.error(ERROR_MESSAGES.resourcesService.saveCalError, err);
-            res
-              .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .send({
-                message:
-                  ERROR_MESSAGES.resourcesService.saveCalError +
-                  ': ' +
-                  err.message,
-              });
+            res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
+              message:
+                ERROR_MESSAGES.resourcesService.saveCalError +
+                ': ' +
+                err.message,
+            });
           }
         }
       },


### PR DESCRIPTION
# Description

Based on the logs I added, I think that calendars for old courses are still on our server not because the cron job isn't deleting them properly, but because the calendar endpoints for those courses are somehow still being hit. That causes the server to redownload the files. I'm adding a check in the calendar endpoint to avoid downloading calendars for disabled courses, and just throw a 404 error back at them. Hopefully this should make sure our uploads folder stays clean. 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
