### PR TITLE
Course roster page frontend

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -31,8 +31,8 @@ import {
   UpdateQuestionResponse,
   UpdateQueueParams,
   QueuePartial,
-  UserPartial,
   Role,
+  GetCourseUserInfoResponse,
 } from "@koh/common";
 import Axios, { AxiosInstance, Method } from "axios";
 import { plainToClass } from "class-transformer";
@@ -86,12 +86,12 @@ class APIClient {
       page: number,
       role?: Role,
       search?: string
-    ) =>
+    ): Promise<GetCourseUserInfoResponse> =>
       this.req(
         "GET",
-        `/api/v1/courses/${courseId}/get_user_info/${page}/${role}`,
-        UserPartial,
-        { search }
+        `/api/v1/courses/${courseId}/get_user_info/${page}/${role}${
+          search ? `?search=${search}` : ""
+        }`
       ),
     getCourseOverrides: async (courseId: number) =>
       this.req(

--- a/packages/app/components/Settings/CourseAdminPanel.tsx
+++ b/packages/app/components/Settings/CourseAdminPanel.tsx
@@ -8,13 +8,13 @@ import { useRouter } from "next/router";
 import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
 import { useProfile } from "../../hooks/useProfile";
-import CourseOverrideSettings from "./CourseOverrideSettings";
+import CourseRosterPage from "./CourseRosterPage";
 import { SettingsPanelAvatar } from "./SettingsSharedComponents";
 import TACheckInCheckOutTimes from "./TACheckInCheckOutTimes";
 
 export enum CourseAdminOptions {
   CHECK_IN = "CHECK_IN",
-  OVERRIDES = "OVERRIDES",
+  ROSTER = "ROSTER",
 }
 
 interface CourseAdminPageProps {
@@ -77,8 +77,8 @@ export default function CourseAdminPanel({
           <Menu.Item key={CourseAdminOptions.CHECK_IN} icon={<EditOutlined />}>
             TA Check In/Out Times
           </Menu.Item>
-          <Menu.Item key={CourseAdminOptions.OVERRIDES} icon={<BellOutlined />}>
-            Course Overrides
+          <Menu.Item key={CourseAdminOptions.ROSTER} icon={<BellOutlined />}>
+            Course Roster
           </Menu.Item>
         </Menu>
       </Col>
@@ -88,8 +88,8 @@ export default function CourseAdminPanel({
           {currentSettings === CourseAdminOptions.CHECK_IN && (
             <TACheckInCheckOutTimes courseId={courseId} />
           )}
-          {currentSettings === CourseAdminOptions.OVERRIDES && (
-            <CourseOverrideSettings courseId={courseId} />
+          {currentSettings === CourseAdminOptions.ROSTER && (
+            <CourseRosterPage courseId={courseId} />
           )}
         </Col>
       </Space>

--- a/packages/app/components/Settings/CourseOverrideSettings.tsx
+++ b/packages/app/components/Settings/CourseOverrideSettings.tsx
@@ -13,7 +13,6 @@ const { Column } = Table;
 type CourseOverrideSettingsProps = { courseId: number };
 
 const OverrideContents = styled.div`
-  width: 90%;
   margin-left: auto;
   margin-right: auto;
   padding-top: 50px;
@@ -36,6 +35,8 @@ export default function CourseOverrideSettings({
 
   return (
     <OverrideContents>
+      <h1>Course Overrides</h1>
+      <br />
       <AddOverrideInput courseId={courseId} onAddOverride={() => mutate()} />
       <Table
         dataSource={data?.data.map((row, i) => ({
@@ -69,6 +70,7 @@ export default function CourseOverrideSettings({
           )}
         />
       </Table>
+      <br />
       <div>
         Is Khoury Admin/Banner down? Toggle this to temporarily allow students
         to join your class.{" "}
@@ -80,6 +82,7 @@ export default function CourseOverrideSettings({
           defaultChecked={course?.selfEnroll}
         />
       </div>
+      <br />
       <b>
         You must manually toggle this feature off later, or any student will be
         allowed to join your class.

--- a/packages/app/components/Settings/CourseRoster.tsx
+++ b/packages/app/components/Settings/CourseRoster.tsx
@@ -24,7 +24,7 @@ const CourseRosterComponent = styled.div`
 `;
 
 const TableBackground = styled.div`
-  backgroundcolor: white;
+  background-color: white;
 `;
 
 export default function CourseRoster({

--- a/packages/app/components/Settings/CourseRoster.tsx
+++ b/packages/app/components/Settings/CourseRoster.tsx
@@ -1,0 +1,122 @@
+import { SearchOutlined } from "@ant-design/icons";
+import { API } from "@koh/api-client";
+import { Role } from "@koh/common";
+import { Divider, Input, List, Pagination, Spin } from "antd";
+import Avatar from "antd/lib/avatar/avatar";
+import { useState } from "react";
+import { ReactElement } from "react";
+import styled from "styled-components";
+import useSWR from "swr";
+
+type CourseRosterProps = { courseId: number };
+
+type RenderTableProps = {
+  courseId: number;
+  role: Role;
+  listTitle: string;
+  displaySearchBar: boolean;
+  searchPlaceholder: string;
+};
+
+const CourseRosterComponent = styled.div`
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+export default function CourseRoster({
+  courseId,
+}: CourseRosterProps): ReactElement {
+  return (
+    <CourseRosterComponent>
+      <h1>Course Roster</h1>
+      <RenderTable
+        courseId={courseId}
+        role={Role.PROFESSOR}
+        listTitle={"Professors"}
+        displaySearchBar={false}
+        searchPlaceholder=""
+      />
+      <br />
+      <RenderTable
+        courseId={courseId}
+        role={Role.TA}
+        listTitle={"Teaching Assistants"}
+        displaySearchBar={true}
+        searchPlaceholder="Search TAs"
+      />
+      <br />
+      <RenderTable
+        courseId={courseId}
+        role={Role.STUDENT}
+        listTitle={"Students"}
+        displaySearchBar={true}
+        searchPlaceholder="Search students"
+      />
+      <br />
+      <Divider />
+    </CourseRosterComponent>
+  );
+}
+
+function RenderTable({
+  courseId,
+  role,
+  listTitle,
+  displaySearchBar,
+  searchPlaceholder,
+}: RenderTableProps): ReactElement {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const handleSearch = (event) => {
+    event.preventDefault();
+    setSearch(event.target.value);
+    setPage(1);
+  };
+  const { data } = useSWR(
+    `${role}/${page}/${search}`,
+    async () => await API.course.getUserInfo(courseId, page, role, search)
+  );
+  if (!data) {
+    return <Spin tip="Loading..." size="large" />;
+  } else {
+    return (
+      <div style={{ backgroundColor: "white" }}>
+        <div style={{ backgroundColor: "#f0f0f0", height: "56px" }}>
+          <h3 style={{ position: "relative", left: "10px", top: "14px" }}>
+            {listTitle}
+          </h3>
+        </div>
+        {displaySearchBar && (
+          <Input
+            placeholder={searchPlaceholder}
+            prefix={<SearchOutlined />}
+            value={search}
+            onChange={handleSearch}
+          />
+        )}
+        <List
+          dataSource={data.users}
+          renderItem={(item) => (
+            <List.Item key={item.id}>
+              <List.Item.Meta
+                avatar={<Avatar src={item.photoURL} />}
+                title={item.name}
+              />
+              <div>{item.email}</div>
+            </List.Item>
+          )}
+          bordered
+        />
+        {data.total > 50 && (
+          <Pagination
+            current={page}
+            pageSize={50}
+            total={data.total}
+            onChange={(page) => setPage(page)}
+            showSizeChanger={false}
+          />
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/app/components/Settings/CourseRoster.tsx
+++ b/packages/app/components/Settings/CourseRoster.tsx
@@ -23,6 +23,10 @@ const CourseRosterComponent = styled.div`
   margin-right: auto;
 `;
 
+const TableBackground = styled.div`
+  backgroundcolor: white;
+`;
+
 export default function CourseRoster({
   courseId,
 }: CourseRosterProps): ReactElement {
@@ -66,7 +70,12 @@ function RenderTable({
   searchPlaceholder,
 }: RenderTableProps): ReactElement {
   const [page, setPage] = useState(1);
+  const [input, setInput] = useState("");
   const [search, setSearch] = useState("");
+  const handleInput = (event) => {
+    event.preventDefault();
+    setInput(event.target.value);
+  };
   const handleSearch = (event) => {
     event.preventDefault();
     setSearch(event.target.value);
@@ -80,35 +89,40 @@ function RenderTable({
     return <Spin tip="Loading..." size="large" />;
   } else {
     return (
-      <div style={{ backgroundColor: "white" }}>
-        <div style={{ backgroundColor: "#f0f0f0", height: "56px" }}>
-          <h3 style={{ position: "relative", left: "10px", top: "14px" }}>
-            {listTitle}
-          </h3>
-        </div>
-        {displaySearchBar && (
-          <Input
-            placeholder={searchPlaceholder}
-            prefix={<SearchOutlined />}
-            value={search}
-            onChange={handleSearch}
-          />
-        )}
-        <List
-          dataSource={data.users}
-          renderItem={(item) => (
-            <List.Item key={item.id}>
-              <List.Item.Meta
-                avatar={<Avatar src={item.photoURL} />}
-                title={item.name}
-              />
-              <div>{item.email}</div>
-            </List.Item>
+      <>
+        <TableBackground>
+          <div style={{ backgroundColor: "#f0f0f0", height: "56px" }}>
+            <h3 style={{ position: "relative", left: "10px", top: "14px" }}>
+              {listTitle}
+            </h3>
+          </div>
+          {displaySearchBar && (
+            <Input
+              placeholder={searchPlaceholder}
+              prefix={<SearchOutlined />}
+              value={input}
+              onChange={handleInput}
+              onPressEnter={handleSearch}
+            />
           )}
-          bordered
-        />
+          <List
+            dataSource={data.users}
+            renderItem={(item) => (
+              <List.Item key={item.id}>
+                <List.Item.Meta
+                  avatar={<Avatar src={item.photoURL} />}
+                  title={item.name}
+                />
+                <div>{item.email}</div>
+              </List.Item>
+            )}
+            bordered
+          />
+        </TableBackground>
+        <br />
         {data.total > 50 && (
           <Pagination
+            style={{ float: "right" }}
             current={page}
             pageSize={50}
             total={data.total}
@@ -116,7 +130,7 @@ function RenderTable({
             showSizeChanger={false}
           />
         )}
-      </div>
+      </>
     );
   }
 }

--- a/packages/app/components/Settings/CourseRosterPage.tsx
+++ b/packages/app/components/Settings/CourseRosterPage.tsx
@@ -1,0 +1,24 @@
+import { ReactElement } from "react";
+import CourseOverrideSettings from "./CourseOverrideSettings";
+import styled from "styled-components";
+import CourseRoster from "./CourseRoster";
+
+type CourseRosterPageProps = { courseId: number };
+
+const CourseRosterPageComponent = styled.div`
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 50px;
+`;
+
+export default function CourseRosterPage({
+  courseId,
+}: CourseRosterPageProps): ReactElement {
+  return (
+    <CourseRosterPageComponent>
+      <CourseRoster courseId={courseId} />
+      <CourseOverrideSettings courseId={courseId} />
+    </CourseRosterPageComponent>
+  );
+}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -442,6 +442,10 @@ export class GetCourseResponse {
   selfEnroll!: boolean;
 }
 
+export class GetCourseUserInfoResponse {
+  users!: UserPartial[];
+  total!: number;
+}
 export class GetSelfEnrollResponse {
   courses!: CoursePartial[];
 }

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -3,6 +3,7 @@ import {
   ERROR_MESSAGES,
   GetCourseOverridesResponse,
   GetCourseResponse,
+  GetCourseUserInfoResponse,
   QueuePartial,
   RegisterCourseParams,
   Role,
@@ -10,7 +11,6 @@ import {
   TACheckoutResponse,
   UpdateCourseOverrideBody,
   UpdateCourseOverrideResponse,
-  UserPartial,
 } from '@koh/common';
 import {
   BadRequestException,
@@ -597,7 +597,7 @@ export class CourseController {
     @Param('page') page: number,
     @Param('role') role?: Role,
     @Query('search') search?: string,
-  ): Promise<UserPartial[]> {
+  ): Promise<GetCourseUserInfoResponse> {
     const pageSize = 50;
     if (!search) {
       search = '';

--- a/packages/server/src/course/course.service.spec.ts
+++ b/packages/server/src/course/course.service.spec.ts
@@ -173,7 +173,7 @@ describe('CourseService', () => {
     it('returns nothing for a non-existing course id', async () => {
       const courseId = 3;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp).toEqual([]);
+      expect(resp.users).toEqual([]);
     });
 
     it('returns everyone for fundies, no role, no search term', async () => {

--- a/packages/server/src/course/course.service.spec.ts
+++ b/packages/server/src/course/course.service.spec.ts
@@ -179,7 +179,7 @@ describe('CourseService', () => {
     it('returns everyone for fundies, no role, no search term', async () => {
       const courseId = 1;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Angela Zheng',
         'Danish Farooq',
         'Iris Liu',
@@ -200,7 +200,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Danish Farooq',
         'Iris Liu',
       ]);
@@ -216,7 +216,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Neel Bhalla',
         'Tingwei Shi',
         'Vera Kong',
@@ -233,7 +233,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Angela Zheng',
         'Sumit De',
       ]);
@@ -249,7 +249,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual(['Danish Farooq']);
+      expect(resp.users.map((info) => info.name)).toEqual(['Danish Farooq']);
     });
 
     it('returns all tas for algo', async () => {
@@ -262,7 +262,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual(['Vera Kong']);
+      expect(resp.users.map((info) => info.name)).toEqual(['Vera Kong']);
     });
 
     it('returns all students for algo', async () => {
@@ -275,7 +275,7 @@ describe('CourseService', () => {
         search,
         role,
       );
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Sumit De',
         'Tingwei Shi',
       ]);
@@ -284,9 +284,8 @@ describe('CourseService', () => {
     it('returns name, email, and photoURL for user', async () => {
       const courseId = 1;
       search = 'tingwei';
-      const user = (
-        await service.getUserInfo(courseId, page, pageSize, search)
-      )[0] as UserPartial;
+      const user = (await service.getUserInfo(courseId, page, pageSize, search))
+        .users[0] as UserPartial;
       expect(user.name).toEqual('Tingwei Shi');
       expect(user.email).toEqual('tshi@northeastern.edu');
       expect(user.photoURL).toEqual(
@@ -299,8 +298,8 @@ describe('CourseService', () => {
       const role = Role.PROFESSOR;
       search = 'danish';
       const user = (
-        await service.getUserInfo(courseId, page, pageSize, search, role)
-      )[0] as UserPartial;
+        await await service.getUserInfo(courseId, page, pageSize, search, role)
+      ).users[0] as UserPartial;
       expect(user.name).toEqual('Danish Farooq');
     });
 
@@ -309,8 +308,8 @@ describe('CourseService', () => {
       const role = Role.PROFESSOR;
       search = 'farooq';
       const user = (
-        await service.getUserInfo(courseId, page, pageSize, search, role)
-      )[0] as UserPartial;
+        await await service.getUserInfo(courseId, page, pageSize, search, role)
+      ).users[0] as UserPartial;
       expect(user.name).toEqual('Danish Farooq');
     });
 
@@ -320,7 +319,7 @@ describe('CourseService', () => {
       search = 'Danish Farooq';
       const user = (
         await service.getUserInfo(courseId, page, pageSize, search, role)
-      )[0] as UserPartial;
+      ).users[0] as UserPartial;
       expect(user.name).toEqual('Danish Farooq');
     });
 
@@ -328,7 +327,7 @@ describe('CourseService', () => {
       const courseId = 1;
       search = 'd';
       const resp = await service.getUserInfo(courseId, page, pageSize, search);
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Danish Farooq',
         'Sumit De',
       ]);
@@ -338,7 +337,7 @@ describe('CourseService', () => {
       const courseId = 1;
       pageSize = 3;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Angela Zheng',
         'Danish Farooq',
         'Iris Liu',
@@ -350,7 +349,7 @@ describe('CourseService', () => {
       pageSize = 3;
       page = 2;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp.map((info) => info.name)).toEqual([
+      expect(resp.users.map((info) => info.name)).toEqual([
         'Neel Bhalla',
         'Sumit De',
         'Tingwei Shi',
@@ -362,7 +361,7 @@ describe('CourseService', () => {
       pageSize = 3;
       page = 3;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp.map((info) => info.name)).toEqual(['Vera Kong']);
+      expect(resp.users.map((info) => info.name)).toEqual(['Vera Kong']);
     });
 
     it('returns no users for fundies when page size is 3 and page is out of bounds', async () => {
@@ -370,7 +369,7 @@ describe('CourseService', () => {
       pageSize = 3;
       page = 4;
       const resp = await service.getUserInfo(courseId, page, pageSize);
-      expect(resp.map((info) => info.name)).toEqual([]);
+      expect(resp.users.map((info) => info.name)).toEqual([]);
     });
   });
 });

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -4,8 +4,8 @@ import {
   TACheckinTimesResponse,
   RegisterCourseParams,
   Role,
-  UserPartial,
   EditCourseInfoParams,
+  GetCourseUserInfoResponse,
 } from '@koh/common';
 import {
   HttpException,
@@ -326,7 +326,7 @@ export class CourseService {
     pageSize: number,
     search?: string,
     role?: Role,
-  ): Promise<UserPartial[]> {
+  ): Promise<GetCourseUserInfoResponse> {
     const query = await getRepository(UserModel)
       .createQueryBuilder()
       .leftJoin(
@@ -356,19 +356,21 @@ export class CourseService {
     }
 
     // run query
-    const users = query
-      .select([
-        'UserModel.id',
-        'UserModel.firstName',
-        'UserModel.lastName',
-        'UserModel.photoURL',
-        'UserModel.email',
-      ])
+    const users = query.select([
+      'UserModel.id',
+      'UserModel.firstName',
+      'UserModel.lastName',
+      'UserModel.photoURL',
+      'UserModel.email',
+    ]);
+
+    const total = await users.getCount();
+    const usersSubset = await users
       .orderBy('UserModel.firstName')
       .skip((page - 1) * pageSize)
       .take(pageSize)
       .getMany();
 
-    return users;
+    return { users: usersSubset, total };
   }
 }


### PR DESCRIPTION
# Description

Add new course roster page to course admin panel. Lists professors, TAs, and students in course, and allows admin to search through these lists. Also offers pagination over student list

Also makes change to API so that it sends the total number of students/TAs/professors etc. along with the page of users requested

Closes #866

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested to make sure API requests + display worked correctly on dev, added ~ 50 dummy students to test pagination/search features

Top of Page display 

<img width="634" alt="Screen Shot 2022-06-04 at 3 46 21 PM" src="https://user-images.githubusercontent.com/39414740/172023408-e905f11c-2e14-48aa-808d-701ae8a97cd0.png">

Bottom of Page display

<img width="646" alt="Screen Shot 2022-06-04 at 3 46 47 PM" src="https://user-images.githubusercontent.com/39414740/172023391-7d02f1f7-12b9-481d-bb6a-624a3ded308c.png">

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
