### PR TITLE
Automatically disable past semester courses

### DIFF
--- a/packages/server/test/login.integration.ts
+++ b/packages/server/test/login.integration.ts
@@ -503,6 +503,36 @@ describe('Login Integration', () => {
           }
           await course4.reload();
           expect(course4.enabled).toBe(true); // concurrent course stays active
+
+          const summer2 = await SemesterModel.findOne({
+            where: {
+              season: 'Summer_Full',
+              year: 2022,
+            },
+          });
+          const course5 = await CourseFactory.create({ semester: summer2 });
+          await supertest()
+            .post('/khoury_login')
+            .send({
+              email: 'liu.i@northeastern.edu',
+              campus: 1,
+              first_name: 'Iris',
+              last_name: 'Liu',
+              photo_url: 'sdf',
+              courses: [
+                {
+                  crns: [23456],
+                  semester: '202260', // 2022 summer 2
+                  name: 'Fundies 2 Accel',
+                },
+              ],
+            })
+            .expect(201);
+
+          await course4.reload();
+          expect(course4.enabled).toBe(false); // summer1 course now disabled
+          await course5.reload();
+          expect(course5.enabled).toBe(true); // summerFull course still active
         });
       });
     });

--- a/packages/server/test/util/factories.ts
+++ b/packages/server/test/util/factories.ts
@@ -90,6 +90,7 @@ export const LastRegistrationFactory = new Factory(LastRegistrationModel)
 export const ProfSectionGroupsFactory = new Factory(ProfSectionGroupsModel)
   .assocOne('prof', UserFactory)
   .attr('sectionGroups', []);
+
 export const AlertFactory = new Factory(AlertModel)
   .attr('alertType', AlertType.REPHRASE_QUESTION)
   .attr('sent', new Date(Date.now() - 86400000))


### PR DESCRIPTION
# Description

Disable courses from past semesters when the Khoury login payload changes to a previously unseen semester. This eliminates the need for running a manual script; after this, running the app should be completely automatic. 

Generally speaking, each semester disables any other courses which are still enabled, except for some special cases with summer classes. Some summer semesters are concurrent (because of Summer_Full courses), so courses in concurrent semesters do not get disabled. 

Closes #906

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Added integration tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
