### PR TITLE
Df/hide apply modal in percy/cypress tests

### DIFF
--- a/cypress/integration/common/login.spec.js
+++ b/cypress/integration/common/login.spec.js
@@ -9,7 +9,7 @@ describe("Login", () => {
   it("logout works", () => {
     createAndLoginTA();
     cy.visit(`/`);
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
     cy.get(".ant-avatar").click({ force: true });
     cy.get("[data-cy='logout-button']").should(
       "have.attr",

--- a/cypress/integration/common/login.spec.js
+++ b/cypress/integration/common/login.spec.js
@@ -9,7 +9,6 @@ describe("Login", () => {
   it("logout works", () => {
     createAndLoginTA();
     cy.visit(`/`);
-    cy.get(".ant-modal-close-x").click({ multiple: true });
     cy.get(".ant-avatar").click({ force: true });
     cy.get("[data-cy='logout-button']").should(
       "have.attr",

--- a/cypress/integration/ta/allow_or_disable_questions.spec.js
+++ b/cypress/integration/ta/allow_or_disable_questions.spec.js
@@ -64,9 +64,6 @@ describe("When allow questions is disabled", () => {
 
     cy.visit(`/course/${this.queue.courseId}/today`);
 
-    cy.get(".ant-modal-close-x").click({ multiple: true });
-    cy.get(".ant-modal-close-x").should("not.be.visible");
-
     // Check that the queue is not acccpeting new questions on the today page
     cy.get('[data-icon="stop"]').should("exist");
 

--- a/cypress/integration/ta/allow_or_disable_questions.spec.js
+++ b/cypress/integration/ta/allow_or_disable_questions.spec.js
@@ -64,7 +64,7 @@ describe("When allow questions is disabled", () => {
 
     cy.visit(`/course/${this.queue.courseId}/today`);
 
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
     cy.get(".ant-modal-close-x").should("not.be.visible");
 
     // Check that the queue is not acccpeting new questions on the today page

--- a/cypress/integration/ta/edit_queue_notes.spec.js
+++ b/cypress/integration/ta/edit_queue_notes.spec.js
@@ -10,7 +10,7 @@ describe("Edit Queue Notes", () => {
 
   it("can successfully edit queue notes as a ta on today page", function () {
     cy.visit(`/course/${this.queue.course.id}/today`);
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
     taOpenOnline();
     cy.visit(`/course/${this.queue.course.id}/today`);
 

--- a/cypress/integration/ta/edit_queue_notes.spec.js
+++ b/cypress/integration/ta/edit_queue_notes.spec.js
@@ -10,10 +10,9 @@ describe("Edit Queue Notes", () => {
 
   it("can successfully edit queue notes as a ta on today page", function () {
     cy.visit(`/course/${this.queue.course.id}/today`);
-    cy.get(".ant-modal-close-x").click({ multiple: true });
+    cy.wait(1500);
     taOpenOnline();
     cy.visit(`/course/${this.queue.course.id}/today`);
-
 
     cy.get("button[class*='EditNotesButton']").click();
     cy.get("textarea").click().type("alex has a smooth brain");

--- a/cypress/integration/ta/queue_check_in_check_out.spec.js
+++ b/cypress/integration/ta/queue_check_in_check_out.spec.js
@@ -18,10 +18,7 @@ describe("Can successfully check in and out of a queue when their is scheduled o
   it("should check in as TA and view open queues on dropdown", function () {
     // Visit the today page
     cy.visit(`/course/${this.queue.courseId}/today`);
-
-    // close "Welcome to Khoury" modal
-    cy.get(".ant-modal-close-x").click({ multiple: true });
-
+    cy.wait(1500);
     taOpenOnline();
 
     // check Queue tab exists with one queue
@@ -53,7 +50,6 @@ describe("Can successfully check in and out of a queue when their is scheduled o
       queueId: "queue.id",
     });
 
-    cy.get(".ant-modal-close-x").click({ multiple: true });
     // Click "Check in"
     taOpenOnline();
     cy.location("pathname").should("contain", "/queue");
@@ -110,10 +106,10 @@ describe("Can successfully check in and out of a queue when their is scheduled o
     cy.visit(`/course/${this.queue.courseId}/today`);
 
     // Wait for page to load
-    cy.get(".ant-modal-close-x").click({ multiple: true });
     cy.get("button").should("contain", "Check In");
 
     // Click "Check in"
+    cy.wait(1500);
     taOpenOnline();
     cy.location("pathname").should("contain", "/queue");
     cy.get("body").should("contain", "There are no questions in the queue");

--- a/cypress/integration/ta/queue_check_in_check_out.spec.js
+++ b/cypress/integration/ta/queue_check_in_check_out.spec.js
@@ -20,7 +20,7 @@ describe("Can successfully check in and out of a queue when their is scheduled o
     cy.visit(`/course/${this.queue.courseId}/today`);
 
     // close "Welcome to Khoury" modal
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
 
     taOpenOnline();
 
@@ -53,7 +53,7 @@ describe("Can successfully check in and out of a queue when their is scheduled o
       queueId: "queue.id",
     });
 
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
     // Click "Check in"
     taOpenOnline();
     cy.location("pathname").should("contain", "/queue");
@@ -110,7 +110,7 @@ describe("Can successfully check in and out of a queue when their is scheduled o
     cy.visit(`/course/${this.queue.courseId}/today`);
 
     // Wait for page to load
-    cy.get(".ant-modal-close-x").click();
+    cy.get(".ant-modal-close-x").click({ multiple: true });
     cy.get("button").should("contain", "Check In");
 
     // Click "Check in"

--- a/cypress/integration/ta/queue_create_inperson_or_online.spec.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.spec.js
@@ -10,11 +10,9 @@ describe('Can successfully create queues', () => {
         it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
             const roomName = "Snell 049"
             cy.visit(`/course/${this.ta.course.id}/today`);
-            cy.get(".ant-modal-close-x").click({ multiple: true });
-
+            cy.wait(1500);
 
             cy.get("[data-cy=\"check-in-modal-button\"]").click();
-            cy.wait(500);
 
             // name the other OH field
             cy.get("[data-cy=\"qc-location\"]")
@@ -48,6 +46,7 @@ describe('Can successfully create queues', () => {
                 identifier: "ta2",
                 courseId: "ta.course.id",
             });
+            cy.wait(1500);
 
 
             cy.get("[data-cy='check-in-modal-button']").click();
@@ -84,7 +83,6 @@ describe('Can successfully create queues', () => {
                 courseId: "ta.course.id",
             });
             cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click({ multiple: true });
             cy.wait(1000);
             // open the online queue
             taOpenOnline();
@@ -105,7 +103,7 @@ describe('Can successfully create queues', () => {
 
         it('Checks properties of the TA queue-create', function () {
             cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click({ multiple: true });
+            cy.wait(1500);
             cy.get("[data-cy=\"check-in-modal-button\"]")
                 .should("be.visible")
                 .should("not.be.disabled")
@@ -175,7 +173,7 @@ describe('Can successfully create queues', () => {
 
         it('Checks properties of the prof queue-create', function () {
             cy.visit(`/course/${this.professor.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click({ multiple: true });
+            cy.wait(1500);
             cy.get("[data-cy=\"check-in-modal-button\"]")
                 .should("be.visible")
                 .should("not.be.disabled")

--- a/cypress/integration/ta/queue_create_inperson_or_online.spec.js
+++ b/cypress/integration/ta/queue_create_inperson_or_online.spec.js
@@ -10,7 +10,7 @@ describe('Can successfully create queues', () => {
         it('Creates an in-person queue via modal, and Other TAs can join custom in-person queues', function () {
             const roomName = "Snell 049"
             cy.visit(`/course/${this.ta.course.id}/today`);
-            cy.get(".ant-modal-close-x").click();
+            cy.get(".ant-modal-close-x").click({ multiple: true });
 
 
             cy.get("[data-cy=\"check-in-modal-button\"]").click();
@@ -84,7 +84,7 @@ describe('Can successfully create queues', () => {
                 courseId: "ta.course.id",
             });
             cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click();
+            cy.get(".ant-modal-close-x").click({ multiple: true });
             cy.wait(1000);
             // open the online queue
             taOpenOnline();
@@ -105,7 +105,7 @@ describe('Can successfully create queues', () => {
 
         it('Checks properties of the TA queue-create', function () {
             cy.visit(`/course/${this.ta.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click();
+            cy.get(".ant-modal-close-x").click({ multiple: true });
             cy.get("[data-cy=\"check-in-modal-button\"]")
                 .should("be.visible")
                 .should("not.be.disabled")
@@ -175,7 +175,7 @@ describe('Can successfully create queues', () => {
 
         it('Checks properties of the prof queue-create', function () {
             cy.visit(`/course/${this.professor.course.id}/today`, {timeout: 20000});
-            cy.get(".ant-modal-close-x").click();
+            cy.get(".ant-modal-close-x").click({ multiple: true });
             cy.get("[data-cy=\"check-in-modal-button\"]")
                 .should("be.visible")
                 .should("not.be.disabled")

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -51,6 +51,9 @@ export const loginUser = (identifier) => {
  */
 const createUserAndLogin = ({ role, courseId, identifier }) => {
   const req = (parsedId) => {
+
+    cy.window().then(win => win.localStorage.setItem('firstTime', false));
+    cy.window().then(win => win.localStorage.setItem('seenApplyModal', false));
     // create the user
     cy.request("POST", "/api/v1/seeds/createUser", {
       role: role,
@@ -221,21 +224,20 @@ export const helpQuestionWithID = (id) => {
  * Opens up the modal and checks into the default option (usually online if created)
  */
 export const taOpenOnline = () => {
+  cy.get("[data-cy='check-in-modal-button']").click();
+  cy.wait(500);
+  cy.get("[data-cy=\"select-existing-queue\"]").click();
+  cy.get('[data-cy="select-queue-Online"]').click();
 
-    cy.get("[data-cy='check-in-modal-button']").click();
-    cy.wait(500);
-    cy.get("[data-cy=\"select-existing-queue\"]").click();
-    cy.get('[data-cy="select-queue-Online"]').click();
-
-    cy.get("[id^=rcDialogTitle]")
-        .contains("Check into a queue")
+  cy.get("[id^=rcDialogTitle]")
+    .contains("Check into a queue")
+    .parent()
+    .parent()
+    .should('have.class', 'ant-modal-content')
+    .within(($content) => {
+      cy.get("span").contains("Check In")
         .parent()
-        .parent()
-        .should('have.class', 'ant-modal-content')
-        .within(($content) => {
-            cy.get("span").contains("Check In")
-                .parent()
-                .should('have.class', 'ant-btn-primary')
-                .click();
-        });
+        .should('have.class', 'ant-btn-primary')
+        .click();
+    });
 }

--- a/packages/app/components/Today/SandboxApplication.tsx
+++ b/packages/app/components/Today/SandboxApplication.tsx
@@ -15,6 +15,7 @@ export default function ApplyToSandbox(): ReactElement {
       footer={null}
       onCancel={() => setFirstTime(false)}
       width={625}
+      className="hide-in-percy"
     >
       <div>
         <h1> Sandbox Applications Are Now Open! 🎉</h1>


### PR DESCRIPTION
# Description
I hid the apply modal in percy (but even better, i use local storage to prevent the modals from rendering in the first place)

we still face the issue where we infinitely fetch old calendars though :/

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

# How Has This Been Tested?
I ran the cyress tests locally 🤯 , and theyll run again in CI 😎 
