### PR TITLE
do not include forced checkout in OH heatmap overlay

### DIFF
--- a/packages/server/src/course/heatmap.service.ts
+++ b/packages/server/src/course/heatmap.service.ts
@@ -4,9 +4,9 @@ import { Cache } from 'cache-manager';
 import { ClosedQuestionStatus, Heatmap, timeDiffInMins } from '@koh/common';
 import moment = require('moment');
 import { CourseModel } from './course.entity';
-import { MoreThan } from 'typeorm';
+import { MoreThan, Not } from 'typeorm';
 import { QuestionModel } from '../question/question.entity';
-import { EventModel } from '../profile/event-model.entity';
+import { EventModel, EventType } from '../profile/event-model.entity';
 import { Command, Positional } from 'nestjs-command';
 import { inRange, mean, range } from 'lodash';
 import 'moment-timezone';
@@ -54,7 +54,11 @@ export class HeatmapService {
     }
 
     const taEvents = await EventModel.find({
-      where: { time: MoreThan(recent), courseId },
+      where: {
+        time: MoreThan(recent),
+        courseId,
+        eventType: Not(EventType.TA_CHECKED_OUT_FORCED),
+      },
     });
 
     if (taEvents.length === 0) {


### PR DESCRIPTION
# Description
the heatmap is extending to midnight even tho OH dont go until then. This is partly because of TAs that forget to check out at night. To ensure the data is cleaner, we can exclude these from the OH overlay of -1s onto the heatmap array

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
It just kinda works. i probably should write a test though.

# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
